### PR TITLE
fix!: suppress warning when using npm v9

### DIFF
--- a/src/static.ts
+++ b/src/static.ts
@@ -110,7 +110,7 @@ export interface Events {
   SmokeOk: void;
   SmokeFailed: (err: Error) => void;
   FindNpmBegin: void;
-  FindNpmOk: string;
+  FindNpmOk: NpmInfo;
   FindNpmFailed: (err: Error) => void;
 
   PackBegin: void;
@@ -131,7 +131,7 @@ export interface Events {
     total: number;
     executed: number;
     failures: number;
-    results: Array<ExecaReturnValue<string>|ExecaError<string>>;
+    results: Array<ExecaReturnValue<string> | ExecaError<string>>;
     scripts: string[];
   };
   RunScriptsOk: {
@@ -163,3 +163,8 @@ export interface Events {
 }
 
 export type TSmokerEmitter = StrictEventEmitter<EventEmitter, Events>;
+
+export interface NpmInfo {
+  path: string;
+  version: string;
+}


### PR DESCRIPTION
BREAKING CHANGE: npm v9 changes `--global-style` to `--install-strategy=shallow`.  so now we need to retain the version that we found when running `which npm`, and change the shell command accordingly.  Note that even passing a custom path to `npm` will cause it to be executed so that we can verify the version.  This also modifies the `FIND_NPM_OK` event to return an `NpmInfo` object containing props `path` and `version`, instead of just the `string` path.
