### PR TITLE
fix: add corepack as dependency

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,14 +1,20 @@
+root: true
+
 env:
   es2020: true
   node: true
+
 extends:
   - 'semistandard'
   - 'plugin:@typescript-eslint/recommended'
   - 'prettier'
+
 ignorePatterns:
   - 'node_modules/**/*'
   - 'coverage/**/*'
   - 'dist/**/*'
+  - '__snapshots__/**/*'
+
 overrides:
   - files:
       - 'bin/**/*'
@@ -22,10 +28,8 @@ overrides:
       '@typescript-eslint/no-unused-vars': 'off'
 
 parser: '@typescript-eslint/parser'
-plugins:
-  - '@typescript-eslint'
+
 rules:
   '@typescript-eslint/no-explicit-any': 'off'
   'no-useless-constructor': 'off'
   'lines-between-class-members': 'off'
-root: true

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ It's recommended to install `midnight-smoker` as a dev dependency, if you want t
 
 Run `npm install midnight-smoker --save-dev`.
 
-- Node.js versions supported: `^16.13.0 || ^18.0.0 || ^20.0.0`
+- Node.js versions supported: `^16.20.0 || ^18.0.0 || ^20.0.0`
 - Minimum `npm` version supported: `v7.0.0`
 
 While odd-numbered Node.js releases _may_ work, they are not tested on and not officially supported.

--- a/__snapshots__/cli.spec.ts.js
+++ b/__snapshots__/cli.spec.ts.js
@@ -3,8 +3,8 @@ exports[
 ] = `
 💨 midnight-smoker v<version>
 - Packing current project...
-✔ Packed 1 unique package using npm@9.8.1…
-- Installing 1 unique package from tarball using npm@9.8.1…
+✔ Packed 1 unique package using npm@<version>…
+- Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
 - Running script 0/1...
 ✔ Successfully ran 1 script
@@ -16,15 +16,15 @@ exports[
 ] = `
 💨 midnight-smoker v<version>
 - Packing current project...
-✔ Packed 1 unique package using npm@9.8.1…
-- Installing 1 unique package from tarball using npm@9.8.1…
+✔ Packed 1 unique package using npm@<version>…
+- Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
 - Running script 0/1...
 ✖ 1 of 1 script failed
 
 Error details for failed package fail:
 
-(runScript) Script "smoke" in package "fail" failed: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/bin/corepack npm@9.8.1 run smoke
+(runScript) Script "smoke" in package "fail" failed: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke
 
 > fail@1.0.0 smoke
 > exit 1
@@ -37,8 +37,8 @@ exports[
 ] = `
 💨 midnight-smoker v<version>
 - Packing current project...
-✔ Packed 1 unique package using npm@9.8.1…
-- Installing 1 unique package from tarball using npm@9.8.1…
+✔ Packed 1 unique package using npm@<version>…
+- Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
 - Running script 0/2...
 ✔ Successfully ran 2 scripts
@@ -82,8 +82,8 @@ exports[
       "pkgName": "single-script",
       "script": "smoke",
       "rawResult": {
-        "command": "<path/to/>/bin/node <path/to/>/bin/corepack npm@9.8.1 run smoke",
-        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/bin/corepack\\" \\"npm@9.8.1\\" run smoke",
+        "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
+        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/.bin/corepack\\" \\"npm@<version>\\" run smoke",
         "exitCode": 0,
         "stdout": "\\n> single-script@1.0.0 smoke\\n> exit 0\\n",
         "stderr": "",
@@ -96,7 +96,7 @@ exports[
     }
   ],
   "manifest": {
-    "npm@9.8.1": [
+    "npm@<version>": [
       {
         "packedPkg": {
           "tarballFilepath": "<tarball.tgz>",
@@ -122,9 +122,9 @@ exports[
       "script": "smoke",
       "error": {},
       "rawResult": {
-        "shortMessage": "Command failed with exit code 1: <path/to/>/bin/node <path/to/>/bin/corepack npm@9.8.1 run smoke",
-        "command": "<path/to/>/bin/node <path/to/>/bin/corepack npm@9.8.1 run smoke",
-        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/bin/corepack\\" \\"npm@9.8.1\\" run smoke",
+        "shortMessage": "Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
+        "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
+        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/.bin/corepack\\" \\"npm@<version>\\" run smoke",
         "exitCode": 1,
         "stdout": "\\n> fail@1.0.0 smoke\\n> exit 1\\n",
         "stderr": "",
@@ -137,7 +137,7 @@ exports[
     }
   ],
   "manifest": {
-    "npm@9.8.1": [
+    "npm@<version>": [
       {
         "packedPkg": {
           "tarballFilepath": "<tarball.tgz>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/semver": "7.5.0",
         "chalk": "4.1.2",
+        "corepack": "0.19.0",
         "debug": "4.3.4",
         "execa": "5.1.1",
         "lilconfig": "2.1.0",
@@ -64,7 +65,7 @@
         "unexpected-sinon": "11.1.0"
       },
       "engines": {
-        "node": "^16.13.0 || ^18.0.0 || ^20.0.0",
+        "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
         "npm": ">=7"
       }
     },
@@ -550,20 +551,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
-      "dev": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "dev": true,
@@ -1035,8 +1022,9 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1051,8 +1039,9 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1082,6 +1071,18 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1724,8 +1725,9 @@
     },
     "node_modules/cli-truncate": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
@@ -1739,8 +1741,9 @@
     },
     "node_modules/cli-truncate/node_modules/ansi-regex": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1750,13 +1753,15 @@
     },
     "node_modules/cli-truncate/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/cli-truncate/node_modules/string-width": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1770,9 +1775,10 @@
       }
     },
     "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.0.1",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1923,6 +1929,21 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/corepack": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/corepack/-/corepack-0.19.0.tgz",
+      "integrity": "sha512-mG4nu1zM5autGOSxl+rrpbx7+ZBhn3gsgXh0bJQVUg3HOo9RTKQvdj7gmp+CDj5clIySRrnWUtZROGfQPGROyg==",
+      "bin": {
+        "corepack": "dist/corepack.js",
+        "pnpm": "dist/pnpm.js",
+        "pnpx": "dist/pnpx.js",
+        "yarn": "dist/yarn.js",
+        "yarnpkg": "dist/yarnpkg.js"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -2247,8 +2268,9 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -2718,6 +2740,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -2735,7 +2770,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -2749,9 +2783,10 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2875,8 +2910,9 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3130,25 +3166,15 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.19.0",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globals/node_modules/type-fest": {
-      "version": "0.20.2",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3910,8 +3936,9 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6013,8 +6040,9 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -6247,8 +6275,9 @@
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.0.0",
         "is-fullwidth-code-point": "^4.0.0"
@@ -6261,9 +6290,10 @@
       }
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.1.0",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6273,8 +6303,9 @@
     },
     "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6825,9 +6856,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "@types/semver": "7.5.0",
     "chalk": "4.1.2",
+    "corepack": "0.19.0",
     "debug": "4.3.4",
     "execa": "5.1.1",
     "lilconfig": "2.1.0",
@@ -133,7 +134,7 @@
     "unexpected-sinon": "11.1.0"
   },
   "engines": {
-    "node": "^16.13.0 || ^18.0.0 || ^20.0.0",
+    "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
     "npm": ">=7"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:update-snapshots": "cross-env SNAPSHOT_UPDATE=1 run-s test:e2e"
   },
   "lint-staged": {
-    "*.{js,ts}": [
+    "!(__snapshots__/)*.{js,ts}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -37,25 +37,39 @@ export async function execSmoker(
 export function dump(obj: any): void {
   console.error(inspect(obj, {depth: null, colors: true}));
 }
-export function fixupOutput(stdout: string) {
-  return (
-    stdout
-      // strip the paths to npm/node/corepack in command
-      .replace(
-        /(?:[^" ]+?)(\/bin\/(node|npm|corepack)(?:\.exe|\.cmd)?)/g,
-        '<path/to/>$1',
-      )
-      // strip the versions since it will change
-      .replace(/midnight-smoker@\d+\.\d+\.\d+/, 'midnight-smoker@<version>')
-      .replace(/midnight-smoker v\d+\.\d+\.\d+/, 'midnight-smoker v<version>')
-      .replace(/--version\\n\\n\d+\.\d+\.\d+/, '--version\\n\\n<version>')
-      // strip the path to `cli.js` since it differs per platform
-      .replace(/node(\.exe)?\s+\S+?smoker\.js/, '<path/to/>smoker.js')
-      .replace(/"cwd":\s+"[^"]+"/, '"cwd": "<cwd>"')
-      .replace(
-        /"tarballFilepath":\s+"[^"]+"/,
-        '"tarballFilepath": "<tarball.tgz>"',
-      )
-      .replace(/"installPath":\s+"[^"]+"/, '"installPath": "<some/path>"')
-  );
+
+/**
+ * Strips a bunch of stuff out of a CLI output string that is dependent upon
+ * local paths and current versions, etc; stuff that isn't suitable for snapshots.
+ * @param stdout String of CLI output
+ * @param stripPmVersions If true, replace `version` in `(npm|yarn|pnpm)@<version>` with the string `<version>`.
+ * @returns Fixed output
+ */
+export function fixupOutput(stdout: string, stripPmVersions = true) {
+  let result = stdout
+    // strip the paths to npm/node/corepack in command
+    .replace(
+      /(?:[^" ]+?)(\/(\.)?bin\/(node|npm|corepack)(?:\.exe|\.cmd)?)/g,
+      '<path/to/>$1',
+    )
+    // strip the versions since it will change
+    .replace(/midnight-smoker v\d+\.\d+\.\d+/g, 'midnight-smoker v<version>')
+    .replace(/--version\\n\\n\d+\.\d+\.\d+/g, '--version\\n\\n<version>')
+    // strip the path to `cli.js` since it differs per platform
+    .replace(/node(\.exe)?\s+\S+?smoker\.js/g, '<path/to/>smoker.js')
+    .replace(/"cwd":\s+"[^"]+"/g, '"cwd": "<cwd>"')
+    .replace(
+      /"tarballFilepath":\s+"[^"]+"/g,
+      '"tarballFilepath": "<tarball.tgz>"',
+    )
+    .replace(/"installPath":\s+"[^"]+"/g, '"installPath": "<some/path>"');
+
+  if (stripPmVersions) {
+    result = result.replace(
+      /(npm|yarn|pnpm|midnight-smoker)@\d+\.\d+\.\d+/g,
+      '$1@<version>',
+    );
+  }
+
+  return result;
 }

--- a/test/e2e/package-manager.spec.ts
+++ b/test/e2e/package-manager.spec.ts
@@ -15,7 +15,7 @@ function testInCwd(cwd: string) {
             cwd,
           },
         );
-        const {results} = JSON.parse(fixupOutput(stdout));
+        const {results} = JSON.parse(fixupOutput(stdout, false));
         expect(results, 'to have an item satisfying', {
           rawResult: {
             command: actual
@@ -47,7 +47,7 @@ describe('midnight-smoker', function () {
                 cwd,
               },
             );
-            const {results} = JSON.parse(fixupOutput(stdout));
+            const {results} = JSON.parse(fixupOutput(stdout, false));
             expect(results, 'to have an item satisfying', {
               rawResult: {
                 command: expect.it('not to contain', packageManager),

--- a/test/unit/pm/corepack.spec.ts
+++ b/test/unit/pm/corepack.spec.ts
@@ -24,7 +24,6 @@ describe('midnight-smoker', function () {
       ({CorepackExecutor} = rewiremock.proxy(
         () => require('../../../src/pm/corepack'),
         {
-          which: sandbox.stub().resolves('/usr/bin/phony/corepack'),
           execa: execaMock,
         },
       ));
@@ -57,7 +56,7 @@ describe('midnight-smoker', function () {
             expect(
               execaMock.node,
               'was called with',
-              '/usr/bin/phony/corepack',
+              expect.it('to match', /corepack$/),
             ).and('was called once');
           });
         });
@@ -77,7 +76,7 @@ describe('midnight-smoker', function () {
             expect(
               execaMock.node,
               'was called with',
-              '/usr/bin/phony/corepack',
+              expect.it('to match', /corepack$/),
             ).and('was called once');
           });
         });


### PR DESCRIPTION
BREAKING CHANGE: This package now requires a minimum Node.js of v16.20.0.

`corepack` v0.17.0 which ships with Node.js v16 seems completely broken (at least on my machine!) so we can't rely on the version shipped with Node.js.  This adds `corepack` as a dev dependency, and since the minimum version is Node.js v16.20.0, we have to bump our minimum version as well.

This also simplifies finding the `corepack` executable.
