### PR TITLE
feat: add --loose flag

### DIFF
--- a/__snapshots__/cli.spec.ts.js
+++ b/__snapshots__/cli.spec.ts.js
@@ -60,9 +60,10 @@ Behavior:
   --bail          When running scripts, halt on first error            [boolean]
   --include-root  Include the workspace root; must provide '--all'     [boolean]
   --json          Output JSON only                                     [boolean]
-  --workspace     Run script in a specific workspace or workspaces       [array]
   --pm            Run script(s) with a specific package manager;
                   <npm|yarn|pnpm>[@version]      [array] [default: "npm@latest"]
+  --loose         Ignore missing scripts (used with --all)             [boolean]
+  --workspace     Run script in a specific workspace or workspaces       [array]
 
 Options:
   --version  Show version number                                       [boolean]
@@ -120,7 +121,6 @@ exports[
     {
       "pkgName": "fail",
       "script": "smoke",
-      "error": {},
       "rawResult": {
         "shortMessage": "Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
         "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
@@ -133,7 +133,8 @@ exports[
         "isCanceled": false,
         "killed": false
       },
-      "cwd": "<cwd>"
+      "cwd": "<cwd>",
+      "error": {}
     }
   ],
   "manifest": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,25 +32,72 @@ const DEFAULT_OPTS: Readonly<LilconfigOpts> = Object.freeze({
 });
 
 export interface SmokerConfig {
+  /**
+   * Add an extra package to the list of packages to be installed.
+   */
   add?: string[] | string;
+  /**
+   * Operate on all workspaces.
+   *
+   * The root workspace is omitted unless `includeRoot` is `true`.
+   */
   all?: boolean;
+  /**
+   * Fail on first script failure.
+   */
   bail?: boolean;
+  /**
+   * Operate on the root workspace.
+   *
+   * Only has an effect if `all` is `true`.
+   */
   includeRoot?: boolean;
+  /**
+   * Output JSON only
+   */
   json?: boolean;
+  /**
+   * Do not delete temp directories after completion
+   */
   linger?: boolean;
+  /**
+   * Verbose logging
+   */
   verbose?: boolean;
+  /**
+   * One or more workspaces to run scripts in
+   */
   workspace?: string[] | string;
+  /**
+   * Package manager(s) to use
+   */
   pm?: string[] | string;
+  /**
+   * Script(s) to run.
+   *
+   * Alias of `scripts`
+   */
   script?: string[] | string;
+  /**
+   * Script(s) to run.
+   *
+   * Alias of `script`
+   */
   scripts?: string[] | string;
+  /**
+   * If `true`, fail if a workspace is missing a script
+   */
+  loose?: boolean;
 }
 
+/**
+ * @internal
+ */
 export interface NormalizedSmokerConfig extends SmokerConfig {
   add?: string[];
   workspace?: string[];
   pm?: string[];
   script?: string[];
-
   scripts?: never;
 }
 

--- a/src/pm/pm.ts
+++ b/src/pm/pm.ts
@@ -9,6 +9,11 @@ export interface PackageManagerOpts {
    * If `true`, show STDERR/STDOUT from the package manager
    */
   verbose?: boolean;
+
+  /**
+   * If `true`, ignore missing scripts
+   */
+  loose?: boolean;
 }
 
 export interface PackOpts {

--- a/src/smoker.ts
+++ b/src/smoker.ts
@@ -121,7 +121,11 @@ export class Smoker extends createStrictEventEmitterClass() {
     scripts: string | string[],
     opts: SmokeOptions = {},
   ) {
-    const pms = await loadPackageManagers(opts.pm, {verbose: opts.verbose});
+    const {pm, verbose, loose, all} = opts;
+    const pms = await loadPackageManagers(pm, {
+      verbose,
+      loose: all && loose,
+    });
     return new Smoker(scripts, pms, opts);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface RunScriptResult {
   error?: SmokerError;
   rawResult: RunScriptValue | ExecaError;
   cwd: string;
+  skipped?: boolean;
 }
 
 /**
@@ -95,6 +96,8 @@ export interface SmokeOptions {
   add?: string[];
 
   pm?: string[];
+
+  loose?: boolean;
 }
 
 export type SmokerOptions = Omit<SmokeOptions, 'verbose'>;

--- a/test/e2e/fixture/loose/a/package.json
+++ b/test/e2e/fixture/loose/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "loose-a",
+  "version": "1.0.0",
+  "scripts": {
+    "smoke": "exit 0"
+  }
+}

--- a/test/e2e/fixture/loose/b/package.json
+++ b/test/e2e/fixture/loose/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "loose-b",
+  "version": "1.0.0"
+}

--- a/test/e2e/fixture/loose/package.json
+++ b/test/e2e/fixture/loose/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "loose",
+  "version": "1.0.0",
+  "workspaces": [
+    "a",
+    "b"
+  ],
+  "private": true
+}


### PR DESCRIPTION
This flag, when paired with `--all`, tells `midnight-smoker` to ignore any missing scripts.

Closes #257

fix(yarn): fix workspace-related problems