### PR TITLE
feat!: add builtin checks

### DIFF
--- a/__snapshots__/cli.spec.ts.js
+++ b/__snapshots__/cli.spec.ts.js
@@ -2,11 +2,11 @@ exports[
   'midnight-smoker smoker CLI script single script when the script succeeds should produce expected output 1'
 ] = `
 💨 midnight-smoker v<version>
-- Packing current project...
+- Packing current project…
 ✔ Packed 1 unique package using npm@<version>…
 - Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
-- Running script 0/1...
+- Running script 0/1…
 ✔ Successfully ran 1 script
 ✔ Lovey-dovey! 💖
 `;
@@ -15,19 +15,18 @@ exports[
   'midnight-smoker smoker CLI script single script when the script fails should produce expected output 1'
 ] = `
 💨 midnight-smoker v<version>
-- Packing current project...
+- Packing current project…
 ✔ Packed 1 unique package using npm@<version>…
 - Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
-- Running script 0/1...
+- Running script 0/1…
 ✖ 1 of 1 script failed
-
-Error details for failed package fail:
-
-(runScript) Script "smoke" in package "fail" failed: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke
+ℹ Script failure details for package fail:
+» (runScript) Script "smoke" in package "fail" failed: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke
 
 > fail@1.0.0 smoke
 > exit 1
+
 
 ✖ 🤮 Maurice!
 `;
@@ -36,23 +35,22 @@ exports[
   'midnight-smoker smoker CLI script multiple scripts when the scripts succeed should produce expected output 1'
 ] = `
 💨 midnight-smoker v<version>
-- Packing current project...
+- Packing current project…
 ✔ Packed 1 unique package using npm@<version>…
 - Installing 1 unique package from tarball using npm@<version>…
 ✔ Installed 1 unique package from tarball
-- Running script 0/2...
+- Running script 0/2…
 ✔ Successfully ran 2 scripts
 ✔ Lovey-dovey! 💖
 `;
 
 exports['midnight-smoker smoker CLI option --help should show help text 1'] = `
-smoker <script> [scripts..]
+smoker [scripts..]
 
 Run tests against a package as it would be published
 
 Positionals:
-  script   Script in package.json to run                                [string]
-  scripts  Additional script(s) to run                                  [string]
+  scripts  Script(s) in package.json to run                             [string]
 
 Behavior:
   --add           Additional dependency to provide to script(s)          [array]
@@ -64,6 +62,7 @@ Behavior:
                   <npm|yarn|pnpm>[@version]      [array] [default: "npm@latest"]
   --loose         Ignore missing scripts (used with --all)             [boolean]
   --workspace     Run script in a specific workspace or workspaces       [array]
+  --checks        Run built-in checks                  [boolean] [default: true]
 
 Options:
   --version  Show version number                                       [boolean]
@@ -74,83 +73,155 @@ For more info, see https://github.com/boneskull/midnight-smoker
 `;
 
 exports[
-  'midnight-smoker smoker CLI option --json when the script succeeds should produce expected output 1'
+  'midnight-smoker smoker CLI option --json when the script fails should provide helpful result 1'
 ] = `
 {
-  "failures": 0,
-  "results": [
-    {
-      "pkgName": "single-script",
-      "script": "smoke",
-      "rawResult": {
-        "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
-        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/.bin/corepack\\" \\"npm@<version>\\" run smoke",
-        "exitCode": 0,
-        "stdout": "\\n> single-script@1.0.0 smoke\\n> exit 0\\n",
-        "stderr": "",
-        "failed": false,
-        "timedOut": false,
-        "isCanceled": false,
-        "killed": false
-      },
-      "cwd": "<cwd>"
-    }
-  ],
-  "manifest": {
-    "npm@<version>": [
+  "results": {
+    "scripts": [
       {
-        "packedPkg": {
-          "tarballFilepath": "<tarball.tgz>",
-          "installPath": "<some/path>",
-          "pkgName": "single-script"
+        "pkgName": "fail",
+        "script": "smoke",
+        "rawResult": {
+          "shortMessage": "Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
+          "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
+          "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/.bin/corepack\\" \\"npm@<version>\\" run smoke",
+          "exitCode": 1,
+          "stdout": "\\n> fail@1.0.0 smoke\\n> exit 1\\n",
+          "stderr": "",
+          "failed": true,
+          "timedOut": false,
+          "isCanceled": false,
+          "killed": false
         },
-        "script": "smoke"
+        "cwd": "<cwd>",
+        "error": {
+          "message": "(runScript) Script \\"smoke\\" in package \\"fail\\" failed: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke\\n\\n> fail@1.0.0 smoke\\n> exit 1\\n",
+          "name": "Error",
+          "stack": "Error: (<path/to/file>:<line>:<col>)\\n    at processTicksAndRejections (<path/to/file>:<line>:<col>)\\n    at Smoker.runScripts (<path/to/file>:<line>:<col>)\\n    at Smoker.smoke (<path/to/file>:<line>:<col>)\\n    at Object.handler (<path/to/file>:<line>:<col>)"
+        }
       }
-    ]
+    ],
+    "checks": {
+      "passed": [],
+      "failed": []
+    },
+    "opts": {
+      "_": [],
+      "json": true,
+      "checks": false,
+      "scripts": [
+        "smoke"
+      ],
+      "add": [],
+      "pm": [
+        "npm@latest"
+      ],
+      "workspace": [],
+      "$0": "smoker",
+      "verbose": false
+    }
   },
-  "total": 1,
-  "executed": 1
+  "stats": {
+    "totalPackages": 1,
+    "totalPackageManagers": 1,
+    "totalScripts": 1,
+    "failedScripts": 1,
+    "passedScripts": 0,
+    "totalChecks": null,
+    "failedChecks": null,
+    "passedChecks": null
+  }
 }
 `;
 
 exports[
-  'midnight-smoker smoker CLI option --json when the script fails should provide helpful result 1'
-] = `
-{
-  "results": [
+  'midnight-smoker smoker CLI option --json when the script succeeds should produce expected script output 1'
+] = {
+  scripts: [
     {
-      "pkgName": "fail",
-      "script": "smoke",
-      "rawResult": {
-        "shortMessage": "Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
-        "command": "<path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> run smoke",
-        "escapedCommand": "\\"<path/to/>/bin/node\\" \\"<path/to/>/.bin/corepack\\" \\"npm@<version>\\" run smoke",
-        "exitCode": 1,
-        "stdout": "\\n> fail@1.0.0 smoke\\n> exit 1\\n",
-        "stderr": "",
-        "failed": true,
-        "timedOut": false,
-        "isCanceled": false,
-        "killed": false
+      pkgName: 'single-script',
+      script: 'smoke',
+      rawResult: {
+        command:
+          '<path/to/>/bin/node <path/to/>/.bin/corepack npm@9.8.1 run smoke',
+        escapedCommand:
+          '"<path/to/>/bin/node" "<path/to/>/.bin/corepack" "npm@9.8.1" run smoke',
+        exitCode: 0,
+        stdout: '\n> single-script@1.0.0 smoke\n> exit 0\n',
+        stderr: '',
+        failed: false,
+        timedOut: false,
+        isCanceled: false,
+        killed: false,
       },
-      "cwd": "<cwd>",
-      "error": {}
-    }
+      cwd: '<cwd>',
+    },
   ],
-  "manifest": {
-    "npm@<version>": [
+  checks: {
+    failed: [],
+    passed: [
       {
-        "packedPkg": {
-          "tarballFilepath": "<tarball.tgz>",
-          "installPath": "<some/path>",
-          "pkgName": "fail"
+        rule: {
+          name: 'no-missing-pkg-files',
+          description:
+            'Checks that files referenced in package.json exist in the tarball',
         },
-        "script": "smoke"
-      }
-    ]
+        context: {
+          pkgJson: '<some/path>',
+          pkg: '<some/path>',
+          severity: 'error',
+        },
+        failed: false,
+      },
+      {
+        rule: {
+          name: 'no-banned-files',
+          description: 'Bans certain files from being published',
+        },
+        context: {
+          pkgJson: '<some/path>',
+          pkg: '<some/path>',
+          severity: 'error',
+        },
+        failed: false,
+      },
+      {
+        rule: {
+          name: 'no-missing-entry-point',
+          description:
+            'Checks that the package contains an entry point; only applies to CJS packages without an "exports" field',
+        },
+        context: {
+          pkgJson: '<some/path>',
+          pkg: '<some/path>',
+          severity: 'error',
+        },
+        failed: false,
+      },
+      {
+        rule: {
+          name: 'no-missing-exports',
+          description:
+            'Checks that all files in the "exports" field (if present) exist',
+        },
+        context: {
+          pkgJson: '<some/path>',
+          pkg: '<some/path>',
+          severity: 'error',
+        },
+        failed: false,
+      },
+    ],
   },
-  "total": 1,
-  "failures": 1,
-  "executed": 1
-}
-`;
+  opts: {
+    _: [],
+    json: true,
+    scripts: ['smoke'],
+    add: [],
+    pm: ['npm@latest'],
+    workspace: [],
+    checks: true,
+    $0: 'smoker',
+    verbose: false,
+  },
+};

--- a/data/git-deny-patterns.json
+++ b/data/git-deny-patterns.json
@@ -1,0 +1,408 @@
+[
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^.*_rsa$",
+    "caption": "Private SSH key",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^.*_dsa$",
+    "caption": "Private SSH key",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^.*_ed25519$",
+    "caption": "Private SSH key",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^.*_ecdsa$",
+    "caption": "Private SSH key",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "pem",
+    "caption": "Potential cryptographic private key",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "ppk",
+    "caption": "Potential cryptographic private key",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "regex",
+    "pattern": "^key(pair)?$",
+    "caption": "Potential cryptographic private key",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "pkcs12",
+    "caption": "Potential cryptographic key bundle",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "pfx",
+    "caption": "Potential cryptographic key bundle",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "p12",
+    "caption": "Potential cryptographic key bundle",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "asc",
+    "caption": "Potential cryptographic key bundle",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "otr.private_key",
+    "caption": "Pidgin OTR private key",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?(bash_|zsh_|z)?history$",
+    "caption": "Shell command history file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?mysql_history$",
+    "caption": "MySQL client command history file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?psql_history$",
+    "caption": "PostgreSQL client command history file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?irb_history$",
+    "caption": "Ruby IRB console history file",
+    "description": null
+  },
+  {
+    "part": "path",
+    "type": "regex",
+    "pattern": "\\.?purple\\/accounts\\.xml$",
+    "caption": "Pidgin chat client account configuration file",
+    "description": null
+  },
+  {
+    "part": "path",
+    "type": "regex",
+    "pattern": "\\.?xchat2?\\/servlist_?\\.conf$",
+    "caption": "Hexchat/XChat IRC client server list configuration file",
+    "description": null
+  },
+  {
+    "part": "path",
+    "type": "regex",
+    "pattern": "\\.?irssi\\/config$",
+    "caption": "Irssi IRC client configuration file",
+    "description": null
+  },
+  {
+    "part": "path",
+    "type": "regex",
+    "pattern": "\\.?recon-ng\\/keys\\.db$",
+    "caption": "Recon-ng web reconnaissance framework API key database",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?dbeaver-data-sources.xml$",
+    "caption": "DBeaver SQL database manager configuration file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?muttrc$",
+    "caption": "Mutt e-mail client configuration file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?s3cfg$",
+    "caption": "S3cmd configuration file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?trc$",
+    "caption": "T command-line Twitter client configuration file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "ovpn",
+    "caption": "OpenVPN client configuration file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?gitrobrc$",
+    "caption": "Well, this is awkward... Gitrob configuration file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?(bash|zsh)rc$",
+    "caption": "Shell configuration file",
+    "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?(bash_|zsh_)?profile$",
+    "caption": "Shell profile configuration file",
+    "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?(bash_|zsh_)?aliases$",
+    "caption": "Shell command alias configuration file",
+    "description": "Shell configuration files might contain information such as server hostnames, passwords and API keys."
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "secret_token.rb",
+    "caption": "Ruby On Rails secret token configuration file",
+    "description": "If the Rails secret token is known, it can allow for remote code execution. (http://www.exploit-db.com/exploits/27527/)"
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "omniauth.rb",
+    "caption": "OmniAuth configuration file",
+    "description": "The OmniAuth configuration file might contain client application secrets."
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "carrierwave.rb",
+    "caption": "Carrierwave configuration file",
+    "description": "Can contain credentials for online storage systems such as Amazon S3 and Google Storage."
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "schema.rb",
+    "caption": "Ruby On Rails database schema file",
+    "description": "Contains information on the database schema of a Ruby On Rails application."
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "database.yml",
+    "caption": "Potential Ruby On Rails database configuration file",
+    "description": "Might contain database credentials."
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "settings.py",
+    "caption": "Django configuration file",
+    "description": "Might contain database credentials, online storage system credentials, secret keys, etc."
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^(.*)?config(\\.inc)?\\.php$",
+    "caption": "PHP configuration file",
+    "description": "Might contain credentials and keys."
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "kdb",
+    "caption": "KeePass password manager database file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "agilekeychain",
+    "caption": "1Password password manager database file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "keychain",
+    "caption": "Apple Keychain database file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "regex",
+    "pattern": "^key(store|ring)$",
+    "caption": "GNOME Keyring database file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "log",
+    "caption": "Log file",
+    "description": "Log files might contain information such as references to secret HTTP endpoints, session IDs, user information, passwords and API keys."
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "pcap",
+    "caption": "Network traffic capture file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "regex",
+    "pattern": "^sql(dump)?$",
+    "caption": "SQL dump file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "gnucash",
+    "caption": "GnuCash database file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "backup",
+    "caption": "Contains word: backup",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "dump",
+    "caption": "Contains word: dump",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "password",
+    "caption": "Contains word: password",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "private.*key",
+    "caption": "Contains words: private, key",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml",
+    "caption": "Jenkins publish over SSH plugin file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "credentials.xml",
+    "caption": "Potential Jenkins credentials file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?htpasswd$",
+    "caption": "Apache htpasswd file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^\\.?netrc$",
+    "caption": "Configuration file for auto-login process",
+    "description": "Might contain username and password."
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "kwallet",
+    "caption": "KDE Wallet Manager database file",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": "LocalSettings.php",
+    "caption": "Potential MediaWiki configuration file",
+    "description": null
+  },
+  {
+    "part": "extension",
+    "type": "match",
+    "pattern": "tblk",
+    "caption": "Tunnelblick VPN configuration file",
+    "description": null
+  },
+  {
+    "part": "path",
+    "type": "regex",
+    "pattern": "^\\.?gem/credentials$",
+    "caption": "Rubygems credentials file",
+    "description": "Might contain API key for a rubygems.org account."
+  },
+  {
+    "part": "filename",
+    "type": "regex",
+    "pattern": "^.*\\.pubxml(\\.user)?$",
+    "caption": "Potential MSBuild publish profile",
+    "description": null
+  },
+  {
+    "part": "filename",
+    "type": "match",
+    "pattern": ".env",
+    "caption": "PHP dotenv",
+    "description": "Environment file that contains sensitive data"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "corepack": "0.19.0",
         "debug": "4.3.4",
         "execa": "5.1.1",
+        "glob": "10.3.3",
+        "is-file-esm": "1.0.0",
         "lilconfig": "2.1.0",
         "ora": "5.4.1",
         "pluralize": "8.0.0",
@@ -22,7 +24,8 @@
         "source-map-support": "0.5.21",
         "strict-event-emitter-types": "2.0.0",
         "which": "3.0.1",
-        "yargs": "17.7.2"
+        "yargs": "17.7.2",
+        "zod": "3.22.1"
       },
       "bin": {
         "smoker": "bin/smoker.js"
@@ -32,6 +35,7 @@
         "@commitlint/config-conventional": "17.7.0",
         "@tsconfig/node16": "16.1.1",
         "@types/debug": "4.1.8",
+        "@types/is-file-esm": "1.0.0",
         "@types/mocha": "10.0.1",
         "@types/node": "18.17.8",
         "@types/pluralize": "0.0.30",
@@ -62,7 +66,8 @@
         "typescript": "5.1.6",
         "unexpected": "13.2.1",
         "unexpected-eventemitter": "2.4.0",
-        "unexpected-sinon": "11.1.0"
+        "unexpected-sinon": "11.1.0",
+        "zod-to-json-schema": "3.21.4"
       },
       "engines": {
         "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
@@ -8147,6 +8152,15 @@
       "integrity": "sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz",
+      "integrity": "sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==",
+      "dev": true,
+      "peerDependencies": {
+        "zod": "^3.21.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "./src",
     "./dist",
     "./data",
-    "./scripts",
+    "./schema",
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
@@ -51,16 +51,18 @@
     "lint:staged": "lint-staged",
     "husky-install": "husky install",
     "prepare": "run-p husky-install rebuild",
+    "preversion": "run-s update-schema",
     "rebuild": "run-s clean build",
     "smoke:ts": "ts-node -D ./src/cli.ts --version",
     "smoke:js": "node ./bin/smoker.js --version",
     "test": "run-s test:unit test:smoke",
     "test:ci": "run-s test:unit test:smoke test:e2e",
     "test:unit": "mocha \"test/unit/**/*.spec.ts\"",
-    "pretest:e2e": "run-s build",
+    "pretest:e2e": "run-s rebuild",
     "test:e2e": "mocha --timeout 20s --slow 10s \"test/e2e/**/*.spec.ts\"",
     "test:smoke": "node ./bin/smoker.js smoke:ts smoke:js --add ts-node --add @tsconfig/node16",
-    "test:update-snapshots": "cross-env SNAPSHOT_UPDATE=1 run-s test:e2e"
+    "test:update-snapshots": "cross-env SNAPSHOT_UPDATE=1 run-s test:e2e",
+    "update-schema": "ts-node ./scripts/generate-schema.ts && git add -A schema/midnight-smoker.schema.json"
   },
   "lint-staged": {
     "!(__snapshots__/)*.{js,ts}": [
@@ -86,6 +88,8 @@
     "corepack": "0.19.0",
     "debug": "4.3.4",
     "execa": "5.1.1",
+    "glob": "10.3.3",
+    "is-file-esm": "1.0.0",
     "lilconfig": "2.1.0",
     "ora": "5.4.1",
     "pluralize": "8.0.0",
@@ -94,13 +98,15 @@
     "source-map-support": "0.5.21",
     "strict-event-emitter-types": "2.0.0",
     "which": "3.0.1",
-    "yargs": "17.7.2"
+    "yargs": "17.7.2",
+    "zod": "3.22.1"
   },
   "devDependencies": {
     "@commitlint/cli": "17.7.1",
     "@commitlint/config-conventional": "17.7.0",
     "@tsconfig/node16": "16.1.1",
     "@types/debug": "4.1.8",
+    "@types/is-file-esm": "1.0.0",
     "@types/mocha": "10.0.1",
     "@types/node": "18.17.8",
     "@types/pluralize": "0.0.30",
@@ -131,7 +137,8 @@
     "typescript": "5.1.6",
     "unexpected": "13.2.1",
     "unexpected-eventemitter": "2.4.0",
-    "unexpected-sinon": "11.1.0"
+    "unexpected-sinon": "11.1.0",
+    "zod-to-json-schema": "3.21.4"
   },
   "engines": {
     "node": "^16.20.0 || ^18.0.0 || ^20.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,7 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "extra-files": [
-        "README.md"
-      ]
+      "extra-files": ["README.md"]
     }
   }
 }

--- a/schema/midnight-smoker.schema.json
+++ b/schema/midnight-smoker.schema.json
@@ -1,0 +1,330 @@
+{
+  "$ref": "#/definitions/midnight-smoker-config",
+  "definitions": {
+    "midnight-smoker-config": {
+      "type": "object",
+      "properties": {
+        "add": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Add an extra package to the list of packages to be installed."
+        },
+        "all": {
+          "type": "boolean",
+          "description": "Operate on all workspaces. The root workspace is omitted unless `includeRoot` is `true`."
+        },
+        "bail": {
+          "type": "boolean",
+          "description": "Fail on first script failure."
+        },
+        "includeRoot": {
+          "type": "boolean",
+          "description": "Operate on the root workspace. Only has an effect if `all` is `true`."
+        },
+        "json": {
+          "type": "boolean",
+          "description": "Output JSON only."
+        },
+        "linger": {
+          "type": "boolean",
+          "description": "Do not delete temp directories after completion."
+        },
+        "verbose": {
+          "type": "boolean",
+          "description": "Verbose logging."
+        },
+        "workspace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "One or more workspaces to run scripts in."
+        },
+        "pm": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Package manager(s) to use."
+        },
+        "script": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Script(s) to run. Alias of `scripts`."
+        },
+        "scripts": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Script(s) to run. Alias of `script`."
+        },
+        "loose": {
+          "type": "boolean",
+          "description": "If `true`, fail if a workspace is missing a script."
+        },
+        "checks": {
+          "type": "boolean",
+          "description": "If `false`, run no builtin checks."
+        },
+        "rules": {
+          "type": "object",
+          "properties": {
+            "no-banned-files": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "off",
+                    "warn",
+                    "error"
+                  ],
+                  "description": "Severity of a rule. `off` disables the rule, `warn` will warn on violations, and `error` will error on violations.",
+                  "default": "error"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Allow these banned files"
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Deny these additional files"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/1"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/1"
+                    },
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/0"
+                    }
+                  ]
+                }
+              ]
+            },
+            "no-missing-pkg-files": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/0",
+                  "default": "error",
+                  "description": "Severity of a rule. `off` disables the rule, `warn` will warn on violations, and `error` will error on violations."
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "bin": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Check the \"bin\" field (if it exists)"
+                    },
+                    "fields": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": "Check files referenced by these additional top-level fields"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-pkg-files/anyOf/1"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-pkg-files/anyOf/1"
+                    },
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-pkg-files/anyOf/0"
+                    }
+                  ]
+                }
+              ]
+            },
+            "no-missing-entry-point": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/0",
+                  "default": "error",
+                  "description": "Severity of a rule. `off` disables the rule, `warn` will warn on violations, and `error` will error on violations."
+                },
+                {
+                  "not": {}
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-entry-point/anyOf/1"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-entry-point/anyOf/1"
+                    },
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-entry-point/anyOf/0"
+                    }
+                  ]
+                }
+              ]
+            },
+            "no-missing-exports": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-banned-files/anyOf/0",
+                  "default": "error",
+                  "description": "Severity of a rule. `off` disables the rule, `warn` will warn on violations, and `error` will error on violations."
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "types": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Assert a \"types\" conditional export matches a file with a .d.ts extension"
+                    },
+                    "require": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Assert a \"require\" conditional export matches a CJS script"
+                    },
+                    "import": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Assert an \"import\" conditional export matches a ESM module"
+                    },
+                    "order": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Assert conditional export \"default\", if present, is the last export"
+                    },
+                    "glob": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Allow glob patterns in subpath exports"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-exports/anyOf/1"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-exports/anyOf/1"
+                    },
+                    {
+                      "$ref": "#/definitions/midnight-smoker-config/properties/rules/properties/no-missing-exports/anyOf/0"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rule configuration for checks"
+        }
+      },
+      "additionalProperties": false,
+      "description": "midnight-smoker configuration file schema"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env ts-node
+
+import path from 'node:path';
+import {writeFileSync} from 'node:fs';
+import {zodToJsonSchema} from 'zod-to-json-schema';
+import {SmokerConfigSchema} from '../src';
+
+const jsonSchema = zodToJsonSchema(
+  SmokerConfigSchema,
+  'midnight-smoker-config',
+);
+
+writeFileSync(
+  path.join(__dirname, '..', 'schema', 'midnight-smoker.schema.json'),
+  JSON.stringify(jsonSchema, null, 2),
+  'utf8',
+);

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,1 +1,9 @@
-export class SmokerError extends Error {}
+export class SmokerError extends Error {
+  toJSON() {
+    return {
+      message: this.message,
+      name: this.name,
+      stack: this.stack,
+    };
+  }
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,31 +1,107 @@
 import type {SmokerError} from './error';
-import {
-  PackOkEventData,
-  InstallEventData,
-  RunScriptsBeginEventData,
-  RunScriptsFailedEventData,
-  RunScriptsOkEventData,
-  RunScriptEventData,
-  RunScriptFailedEventData,
+import type {RuleConfig, CheckFailure, CheckOk} from './rules';
+import type {
+  InstallManifest,
+  RunManifest,
+  RunScriptResult,
+  SmokeResults,
 } from './types';
 
+export interface InstallEventData {
+  uniquePkgs: string[];
+  packageManagers: string[];
+  manifests: InstallManifest[];
+
+  additionalDeps: string[];
+}
+
+export interface PackBeginEventData {
+  packageManagers: string[];
+}
+
+export type PackOkEventData = InstallEventData;
+
+export interface RunScriptsEventData {
+  manifest: Record<string, RunManifest[]>;
+  total: number;
+}
+
+export type RunScriptsBeginEventData = RunScriptsEventData;
+
+export interface RunScriptsEndEventData extends RunScriptsEventData {
+  results: RunScriptResult[];
+  failed: number;
+  passed: number;
+}
+
+export type RunScriptsOkEventData = RunScriptsEndEventData;
+
+export type RunScriptsFailedEventData = RunScriptsEndEventData;
+
+export interface RunScriptEventData {
+  script: string;
+  pkgName: string;
+  total: number;
+  current: number;
+}
+
+export interface RunScriptFailedEventData extends RunScriptEventData {
+  error: SmokerError;
+}
+
+export interface RunChecksBeginEventData {
+  config: RuleConfig;
+  total: number;
+}
+
+export interface RunCheckEventData {
+  rule: string;
+  config: RuleConfig[keyof RuleConfig];
+  current: number;
+  total: number;
+}
+
+export type RunCheckBeginEventData = RunCheckEventData;
+
+export interface RunCheckFailedEventData extends RunCheckEventData {
+  failed: CheckFailure[];
+}
+
+export type RunCheckOkEventData = RunCheckEventData;
+
+export interface RunChecksEndEventData {
+  total: number;
+  config: RuleConfig;
+  passed: CheckOk[];
+  failed: CheckFailure[];
+}
+
+export type RunChecksFailedEventData = RunChecksEndEventData;
+export type RunChecksOkEventData = RunChecksEndEventData;
+
 export interface SmokerEvents {
-  SmokeBegin: void;
-  SmokeOk: void;
-  SmokeFailed: SmokerError;
-  PackBegin: void;
-  PackFailed: SmokerError;
-  PackOk: PackOkEventData;
   InstallBegin: InstallEventData;
   InstallFailed: SmokerError;
   InstallOk: InstallEventData;
-  RunScriptsBegin: RunScriptsBeginEventData;
-  RunScriptsFailed: RunScriptsFailedEventData;
-  RunScriptsOk: RunScriptsOkEventData;
+  Lingered: string[];
+  PackBegin: PackBeginEventData;
+  PackFailed: SmokerError;
+  PackOk: PackOkEventData;
+  RunCheckBegin: RunCheckEventData;
+  RunCheckFailed: RunCheckFailedEventData;
+  RunCheckOk: RunCheckOkEventData;
+  RunChecksBegin: RunChecksBeginEventData;
+  RunChecksFailed: RunChecksFailedEventData;
+  RunChecksOk: RunChecksOkEventData;
   RunScriptBegin: RunScriptEventData;
   RunScriptFailed: RunScriptFailedEventData;
   RunScriptOk: RunScriptEventData;
-  Lingered: string[];
+  RunScriptsBegin: RunScriptsBeginEventData;
+  RunScriptsFailed: RunScriptsFailedEventData;
+  RunScriptsOk: RunScriptsOkEventData;
+  SmokeBegin: void;
+  SmokeFailed: SmokerError;
+  SmokeOk: SmokeResults;
 }
 
 export const Events = {
@@ -45,4 +121,10 @@ export const Events = {
   RUN_SCRIPT_FAILED: 'RunScriptFailed',
   RUN_SCRIPT_OK: 'RunScriptOk',
   LINGERED: 'Lingered',
+  RUN_CHECKS_BEGIN: 'RunChecksBegin',
+  RUN_CHECKS_FAILED: 'RunChecksFailed',
+  RUN_CHECKS_OK: 'RunChecksOk',
+  RUN_CHECK_BEGIN: 'RunCheckBegin',
+  RUN_CHECK_FAILED: 'RunCheckFailed',
+  RUN_CHECK_OK: 'RunCheckOk',
 } as const satisfies Record<string, keyof SmokerEvents>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export type * from './error';
 export type * from './types';
 export * from './events';
 export * from './smoker';
-export type {SmokerConfig} from './config';
+export {SmokerConfigSchema, type SmokerConfig} from './config';

--- a/src/pm/index.ts
+++ b/src/pm/index.ts
@@ -1,4 +1,4 @@
-import {initLoader} from './loader';
+import {initPMLoader} from './pm-loader';
 import npm7 from './npm7';
 import npm9 from './npm9';
 import yarnClassic from './yarn-classic';
@@ -8,6 +8,11 @@ import type {PackageManagerModule} from './pm';
 
 export type * from './pm';
 
-const builtinPms: PackageManagerModule[] = [npm7, npm9, yarnClassic, yarnBerry];
+export const BuiltinPMs: PackageManagerModule[] = [
+  npm7,
+  npm9,
+  yarnClassic,
+  yarnBerry,
+];
 
-export const loadPackageManagers = initLoader(builtinPms);
+export const loadPackageManagers = initPMLoader(BuiltinPMs);

--- a/src/pm/pm-loader.ts
+++ b/src/pm/pm-loader.ts
@@ -12,7 +12,7 @@ import {normalizeVersion} from './version';
 
 const debug = createDebugger('midnight-smoker:pm:loader');
 
-export function initLoader(builtinPms: PackageManagerModule[] = []) {
+export function initPMLoader(builtinPms: PackageManagerModule[] = []) {
   return async function loadPackageManagers(
     pms: string[] = ['npm'],
     opts: PackageManagerOpts = {},

--- a/src/pm/pm.ts
+++ b/src/pm/pm.ts
@@ -1,5 +1,6 @@
 import type {SemVer} from 'semver';
-import type {InstallManifest, RunManifest, RunScriptResult} from '../types';
+import type {InstallManifest, RunScriptResult} from '../types';
+import type {RunManifest} from '../';
 import type {CorepackExecutor} from './corepack';
 
 export interface InstallOpts {}
@@ -75,6 +76,11 @@ export interface PackageManager {
     opts?: RunScriptOpts,
   ): Promise<RunScriptResult>;
 }
+
+export type InstallResults = Map<
+  PackageManager,
+  [manifest: InstallManifest, result: InstallResult]
+>;
 
 /**
  * A function which returns an object implementing {@linkcode PackageManager}.

--- a/src/pm/version.ts
+++ b/src/pm/version.ts
@@ -1,17 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {valid, validRange, maxSatisfying, type SemVer, parse} from 'semver';
-import {readPackageJson} from '../util';
-import type {ReadResult} from 'read-pkg-up';
 import {SmokerError} from '../error';
-
-async function findDataDir(): Promise<string> {
-  const {path: packagePath} = (await readPackageJson({
-    cwd: __dirname,
-  })) as ReadResult;
-  const root = path.dirname(packagePath);
-  return path.join(root, 'data');
-}
+import {findDataDir} from '../util';
 
 async function cachedRead<T = unknown>(filename: string): Promise<T> {
   if (cachedRead.cache.has(filename)) {

--- a/src/rules/builtin/index.ts
+++ b/src/rules/builtin/index.ts
@@ -1,0 +1,17 @@
+import noBannedFiles from './no-banned-files';
+import noMissingEntryPoint from './no-missing-entry-point';
+import noMissingExports from './no-missing-exports';
+import noMissingPkgFiles from './no-missing-pkg-files';
+export const BuiltinRules = {
+  [noMissingPkgFiles.name]: noMissingPkgFiles,
+  [noBannedFiles.name]: noBannedFiles,
+  [noMissingEntryPoint.name]: noMissingEntryPoint,
+  [noMissingExports.name]: noMissingExports,
+} as const;
+
+export const BuiltinRuleConts = [
+  noMissingPkgFiles.toRuleCont(),
+  noBannedFiles.toRuleCont(),
+  noMissingEntryPoint.toRuleCont(),
+  noMissingExports.toRuleCont(),
+];

--- a/src/rules/builtin/no-banned-files.ts
+++ b/src/rules/builtin/no-banned-files.ts
@@ -1,0 +1,131 @@
+/**
+ * `no-banned-files` checks for banned files in the package.
+ *
+ * Portions of this adapted from [ban-sensitive-files](https://github.com/bahmutov/ban-sensitive-files), including `git-deny-patterns.json` and {@linkcode reToRegExp}.
+ * @module
+ */
+
+import fs from 'node:fs/promises';
+import {createRule} from '../rule';
+import type {CheckFailure} from '../result';
+import path from 'node:path';
+import createDebug from 'debug';
+import {z} from 'zod';
+import {findDataDir} from '../../util';
+
+const debug = createDebug('midnight-smoker:rule:no-banned-files');
+
+/**
+ * One of the items in `git-deny-patterns.json`
+ */
+interface DenyPattern {
+  part: 'filename' | 'extension';
+  type: 'regex' | 'match';
+  pattern: string;
+  caption: string;
+  description: string | null;
+}
+
+let denyPatterns: DenyPattern[];
+/**
+ * Load and cache the deny patterns
+ */
+async function loadDenyPatterns() {
+  if (denyPatterns) {
+    return denyPatterns;
+  }
+  const dataDir = await findDataDir();
+  const patterns = await fs.readFile(
+    path.join(dataDir, 'git-deny-patterns.json'),
+    'utf-8',
+  );
+  denyPatterns = JSON.parse(patterns);
+  return denyPatterns;
+}
+
+const regExMap = new Map<string, RegExp>();
+/**
+ * Just caching some `RegExp` objects.
+ * @param pattern RegExp as a string
+ * @returns A RegExp
+ */
+function getRegExp(pattern: string) {
+  if (!regExMap.has(pattern)) {
+    regExMap.set(pattern, new RegExp(pattern));
+  }
+  return regExMap.get(pattern)!;
+}
+
+/**
+ * Uses a list of {@linkcode DenyPattern} objects to check if a filename is banned
+ * @param filename Filename to check
+ * @returns If the file is banned, a string with a description; otherwise, `undefined`
+ */
+async function isBannedFilename(filename: string): Promise<string | undefined> {
+  denyPatterns = await loadDenyPatterns();
+  for (const {part, type, pattern, caption} of denyPatterns) {
+    const value =
+      part === 'filename'
+        ? filename
+        : path.extname(filename).replace(/^\./, '');
+
+    if (
+      (type === 'match' && value === pattern) ||
+      (type === 'regex' && getRegExp(pattern).test(value))
+    ) {
+      return caption;
+    }
+  }
+}
+
+const noBannedFiles = createRule({
+  async check({pkgPath, fail}, opts) {
+    const queue: string[] = [pkgPath];
+    const failed: CheckFailure[] = [];
+    const allow = new Set(opts?.allow ?? []);
+    const deny = new Set(opts?.deny ?? []);
+
+    while (queue.length) {
+      const dir = queue.pop()!;
+      debug('Reading directory %s', dir);
+      const dirents = await fs.readdir(dir, {withFileTypes: true});
+      for (const dirent of dirents) {
+        if (dirent.isDirectory()) {
+          queue.push(path.join(dir, dirent.name));
+        } else {
+          if (allow.has(dirent.name)) {
+            continue;
+          }
+          if (deny.has(dirent.name)) {
+            failed.push(
+              fail(`Banned file found: ${dirent.name} (per custom deny list)`),
+            );
+          } else {
+            const banned = await isBannedFilename(dirent.name);
+            if (banned) {
+              failed.push(
+                fail(`Banned file found: ${dirent.name} (${banned})`),
+              );
+            }
+          }
+        }
+      }
+    }
+
+    return failed;
+  },
+  name: 'no-banned-files',
+  description: 'Bans certain files from being published',
+  schema: z.object({
+    allow: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('Allow these banned files'),
+    deny: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('Deny these additional files'),
+  }),
+});
+
+export default noBannedFiles;

--- a/src/rules/builtin/no-missing-entry-point.ts
+++ b/src/rules/builtin/no-missing-entry-point.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {createRule} from '../rule';
+
+const DEFAULT_FIELD = 'main';
+
+/**
+ * Default entry points for CJS packages which do not contain a `main` field.
+ *
+ * Order matters.
+ * @see {@link https://nodejs.org/api/modules.html#all-together}
+ */
+const DEFAULT_ENTRY_POINTS = ['index.js', 'index.json', 'index.node'] as const;
+
+const noMissingEntryPoint = createRule({
+  async check({pkgJson, pkgPath, fail}) {
+    // skip if the package has an "exports" field or it's an ESM package
+    if (
+      'exports' in pkgJson ||
+      ('type' in pkgJson && pkgJson.type === 'module')
+    ) {
+      return;
+    }
+
+    // I don't think this should ever be anything other than `main`; change later if needed
+    const field = DEFAULT_FIELD;
+
+    if (pkgJson[field]) {
+      // the field exists, so check the file exists
+      const relativePath = pkgJson[field];
+      const filepath = path.resolve(pkgPath, relativePath);
+      try {
+        await fs.stat(filepath);
+      } catch {
+        return [
+          fail(
+            `No entry point found for package "${pkgJson.name}"; file from field "${field}" unreadable at path: ${relativePath}`,
+          ),
+        ];
+      }
+    } else {
+      // the field doesn't exist, so look at the default entry points in order of precedence
+      let found = false;
+      const queue = [...DEFAULT_ENTRY_POINTS];
+      while (queue.length && !found) {
+        const relativePath = queue.shift()!; // in order!!!
+        const filepath = path.resolve(pkgPath, relativePath);
+        try {
+          await fs.stat(filepath);
+          found = true;
+        } catch {}
+      }
+      if (!found) {
+        return [
+          fail(
+            `No entry point found for package "${pkgJson.name}"; (index.js, index.json or index.node)`,
+          ),
+        ];
+      }
+    }
+  },
+  name: 'no-missing-entry-point',
+  description:
+    'Checks that the package contains an entry point; only applies to CJS packages without an "exports" field',
+});
+
+export default noMissingEntryPoint;

--- a/src/rules/builtin/no-missing-exports.ts
+++ b/src/rules/builtin/no-missing-exports.ts
@@ -1,0 +1,242 @@
+import {glob} from 'glob';
+import isESMFile from 'is-file-esm';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {PackageJson} from 'read-pkg-up';
+import {z} from 'zod';
+import {castArray} from '../../util';
+import {CheckFailure} from '../result';
+import {createRule} from '../rule';
+
+const EXPORTS_FIELD = 'exports';
+const CONDITIONAL_EXPORT_DEFAULT = 'default';
+const CONDITIONAL_EXPORT_REQUIRE = 'require';
+const CONDITIONAL_EXPORT_IMPORT = 'import';
+const CONDITIONAL_EXPORT_TYPES = 'types';
+
+function isESMPkg(pkgJson: PackageJson) {
+  return 'type' in pkgJson && pkgJson.type === 'module';
+}
+
+const noMissingExports = createRule({
+  async check({pkgJson, pkgPath, fail}, opts) {
+    opts = {
+      glob: true,
+      require: true,
+      import: true,
+      types: true,
+      order: true,
+      ...opts,
+    };
+
+    if (!pkgJson[EXPORTS_FIELD]) {
+      if (isESMPkg(pkgJson)) {
+        return [
+          fail(`No "exports" field found for ESM package "${pkgJson.name}"`),
+        ];
+      }
+      return;
+    }
+
+    /**
+     * @param relativePath Path from package root to file
+     * @param baseExportName Export name, if `exports` is an object
+     * @param displayExportName Optional; refers to key in an object field (e.g., `bin` as an object instead of `string`)
+     */
+    const checkFile = async (
+      relativePath: string | null,
+      baseExportName?: string,
+      displayExportName = baseExportName,
+    ): Promise<CheckFailure | undefined> => {
+      // this just means "do not export this"
+      if (relativePath === null) {
+        return;
+      }
+
+      // seems wrong to have an empty string for a path!
+      if (!relativePath) {
+        return fail(
+          displayExportName
+            ? `Export "${displayExportName}" contains an empty path`
+            : 'Export contains empty path',
+        );
+      }
+
+      // use glob only if there's a glob pattern.  premature optimization?
+      if (glob.hasMagic(relativePath, {magicalBraces: true})) {
+        if (opts?.glob === false) {
+          return fail(
+            displayExportName
+              ? `Export "${displayExportName}" contains a glob pattern`
+              : 'Export contains a glob pattern',
+          );
+        }
+        const globSpec = relativePath;
+        const matchingFiles = await glob(globSpec, {
+          cwd: pkgPath,
+        });
+
+        // it's _possible_, but unlikely that we'd have an unreadable file,
+        // so don't bother statting or checking readability
+        if (!matchingFiles.length) {
+          return fail(
+            displayExportName
+              ? `Export "${displayExportName}" matches no files using glob: ${globSpec}`
+              : `Export matches no files using glob: ${globSpec}`,
+          );
+        }
+        return;
+      }
+
+      const filepath = path.resolve(pkgPath, relativePath);
+
+      try {
+        await fs.stat(filepath);
+      } catch {
+        return fail(
+          baseExportName
+            ? `Export "${displayExportName}" unreadable at path: ${relativePath}`
+            : `Export unreadable at path: ${relativePath}`,
+        );
+      }
+
+      if (
+        baseExportName === CONDITIONAL_EXPORT_IMPORT &&
+        opts?.import &&
+        !(await isESMFile(filepath)).esm
+      ) {
+        return fail(
+          baseExportName
+            ? `Expected export "${displayExportName}" to be an ESM module at path: ${relativePath}`
+            : `Expected export to be an ESM module at path: ${relativePath}`,
+        );
+      } else if (
+        baseExportName === CONDITIONAL_EXPORT_REQUIRE &&
+        opts?.require &&
+        (await isESMFile(filepath)).esm
+      ) {
+        return fail(
+          baseExportName
+            ? `Expected export "${displayExportName}" to be a CJS script at path: ${relativePath}`
+            : `Expected export to be a CJS script at path: ${relativePath}`,
+        );
+      } else if (
+        baseExportName === CONDITIONAL_EXPORT_TYPES &&
+        opts?.types &&
+        !path.extname(relativePath).endsWith('.d.ts')
+      ) {
+        return fail(
+          baseExportName
+            ? `Expected export "${displayExportName}" to be a .d.ts file at path: ${relativePath}`
+            : `Expected export to be a .d.ts file at path: ${relativePath}`,
+        );
+      }
+    };
+
+    /**
+     * If `exports` is conditional and contains a `default` key, return a
+     * `RuleFailure` if the `default` key is _not_ the last key in the object
+     * @param exports Conditional or subpath exports
+     */
+    const checkOrder = (exports: Record<string, string | null>) => {
+      if (opts?.order && CONDITIONAL_EXPORT_DEFAULT in exports) {
+        const keys = Object.keys(exports);
+        if (keys[keys.length - 1] !== CONDITIONAL_EXPORT_DEFAULT) {
+          return [
+            fail(
+              `Conditional export "${CONDITIONAL_EXPORT_DEFAULT}" must be the last export`,
+            ),
+          ];
+        }
+      }
+    };
+
+    const exports = pkgJson[EXPORTS_FIELD] as
+      | string
+      | null
+      | Record<string, string | null>;
+
+    if (exports === null) {
+      return [fail(`"${EXPORTS_FIELD}" field canot be null`)];
+    }
+
+    // yeah yeah
+    let result:
+      | (CheckFailure | undefined | (CheckFailure | undefined)[])[]
+      | CheckFailure
+      | undefined;
+
+    if (typeof exports === 'string') {
+      result = await checkFile(exports);
+    } else {
+      result =
+        checkOrder(exports) ??
+        (await Promise.all(
+          Object.entries(exports).map(([name, relativePath]) => {
+            // most certainly an object
+            if (relativePath && typeof relativePath === 'object') {
+              return (
+                checkOrder(relativePath) ??
+                Promise.all(
+                  Object.entries(relativePath).map(
+                    ([deepName, relativePath]) => {
+                      // don't think this can be an object, but might be wrong!
+                      return checkFile(
+                        relativePath as string | null,
+                        deepName,
+                        `${name} » ${deepName}`,
+                      );
+                    },
+                  ),
+                )
+              );
+            }
+
+            // string or null
+            return checkFile(relativePath, name);
+          }),
+        ));
+    }
+
+    return castArray(result).flat().filter(Boolean) as CheckFailure[];
+  },
+  name: 'no-missing-exports',
+  description: `Checks that all files in the "${EXPORTS_FIELD}" field (if present) exist`,
+  schema: z.object({
+    types: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe(
+        `Assert a "${CONDITIONAL_EXPORT_TYPES}" conditional export matches a file with a .d.ts extension`,
+      ),
+    require: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe(
+        `Assert a "${CONDITIONAL_EXPORT_REQUIRE}" conditional export matches a CJS script`,
+      ),
+    import: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe(
+        `Assert an "${CONDITIONAL_EXPORT_IMPORT}" conditional export matches a ESM module`,
+      ),
+    order: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe(
+        `Assert conditional export "${CONDITIONAL_EXPORT_DEFAULT}", if present, is the last export`,
+      ),
+    glob: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe('Allow glob patterns in subpath exports'),
+  }),
+});
+
+export default noMissingExports;

--- a/src/rules/builtin/no-missing-pkg-files.ts
+++ b/src/rules/builtin/no-missing-pkg-files.ts
@@ -1,0 +1,78 @@
+import createDebug from 'debug';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {z} from 'zod';
+import {CheckFailure} from '../result';
+import {createRule} from '../rule';
+
+const debug = createDebug('midnight-smoker:rule:no-missing-pkg-files');
+
+const noMissingPkgFiles = createRule({
+  async check({pkgJson: pkg, pkgPath, fail}, opts) {
+    const fieldsToCheck = opts?.fields ?? [];
+    if (opts?.bin !== false) {
+      fieldsToCheck.push('bin');
+    }
+
+    /**
+     * @param relativePath Path from package root to file
+     * @param field Field name
+     * @param name Optional; refers to key in an object field (e.g., `bin` as an object instead of `string`)
+     * @todo maybe make this a utility function?
+     */
+    const checkFile = async (
+      relativePath: string,
+      field: string,
+      name?: string,
+    ): Promise<CheckFailure | undefined> => {
+      const filepath = path.resolve(pkgPath, relativePath);
+      debug('Checking for %s from field %s', filepath, field);
+      try {
+        await fs.stat(filepath);
+      } catch {
+        return fail(
+          name
+            ? `File "${name}" from "${field}" field unreadable at path: ${relativePath}`
+            : `File from "${field}" field unreadable at path: ${relativePath}`,
+        );
+      }
+    };
+
+    const res = await Promise.all(
+      fieldsToCheck
+        .filter((field) => field in pkg)
+        .map(async (field) => {
+          const value = pkg[field];
+          if (value) {
+            if (typeof value === 'string') {
+              return checkFile(value, field);
+            } else if (!Array.isArray(value) && typeof value === 'object') {
+              return Promise.all(
+                Object.entries(value).map(([name, relativePath]) => {
+                  return checkFile(relativePath, field, name);
+                }),
+              );
+            }
+          }
+        }),
+    );
+
+    return res.flat().filter(Boolean) as CheckFailure[];
+  },
+  name: 'no-missing-pkg-files',
+  description:
+    'Checks that files referenced in package.json exist in the tarball',
+  schema: z.object({
+    bin: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe('Check the "bin" field (if it exists)'),
+    fields: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('Check files referenced by these additional top-level fields'),
+  }),
+});
+
+export default noMissingPkgFiles;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,4 @@
+export * from './rule';
+export * from './rule-config';
+export * from './severity';
+export type * from './result';

--- a/src/rules/result.ts
+++ b/src/rules/result.ts
@@ -1,0 +1,30 @@
+import type {StaticCheckContext, StaticRuleDef} from './rule';
+
+export interface CheckResult {
+  rule: StaticRuleDef;
+  context: StaticCheckContext;
+  failed: boolean;
+}
+
+/**
+ * @todo add better location, somehow
+ */
+export interface CheckResultData {
+  filename?: string;
+  [key: string]: any;
+}
+
+export interface CheckFailure extends CheckResult {
+  message: string;
+  data?: CheckResultData;
+  failed: true;
+}
+
+export interface CheckOk extends CheckResult {
+  failed: false;
+}
+
+export interface CheckResults {
+  failed: CheckFailure[];
+  passed: CheckOk[];
+}

--- a/src/rules/rule-config.ts
+++ b/src/rules/rule-config.ts
@@ -1,0 +1,41 @@
+import {z} from 'zod';
+import noBannedFiles from './builtin/no-banned-files';
+import noMissingEntryPoint from './builtin/no-missing-entry-point';
+import noMissingExports from './builtin/no-missing-exports';
+import noMissingPkgFiles from './builtin/no-missing-pkg-files';
+import {RuleSeverities, RuleSeveritySchema} from './severity';
+
+const BaseRuleConfigSchema = z.object({
+  [noBannedFiles.name]: noBannedFiles.ruleSchema,
+  [noMissingPkgFiles.name]: noMissingPkgFiles.ruleSchema,
+  [noMissingEntryPoint.name]: noMissingEntryPoint.ruleSchema,
+  [noMissingExports.name]: noMissingExports.ruleSchema,
+});
+export type RawRuleConfig = z.infer<typeof BaseRuleConfigSchema>;
+
+export const RuleConfigSchema = BaseRuleConfigSchema.transform((val) => ({
+  ...val,
+  getEnabledRules: () =>
+    new Set(
+      Object.entries(val)
+        .filter(([, severity]) => severity !== RuleSeverities.OFF)
+        .map(([ruleName]) => ruleName as keyof RawRuleConfig),
+    ),
+  isRuleEnabled: (ruleName: string) => {
+    const name = ruleName as keyof RawRuleConfig;
+    return (
+      name in BaseRuleConfigSchema.shape && val[name] !== RuleSeverities.OFF
+    );
+  },
+}));
+
+export type RuleConfig = z.infer<typeof RuleConfigSchema>;
+
+export const DEFAULT_RULE_CONFIG = {
+  [noMissingPkgFiles.name]: noMissingPkgFiles.defaultSeverity,
+  [noBannedFiles.name]: noBannedFiles.defaultSeverity,
+  [noMissingEntryPoint.name]: noMissingEntryPoint.defaultSeverity,
+  [noMissingExports.name]: noMissingExports.defaultSeverity,
+} as const satisfies RawRuleConfig;
+
+export type RuleSeverity = z.infer<typeof RuleSeveritySchema>;

--- a/src/rules/rule.ts
+++ b/src/rules/rule.ts
@@ -1,0 +1,273 @@
+import type {PackageJson} from 'read-pkg-up';
+import {z} from 'zod';
+import type {RuleSeverity} from './rule-config';
+import type {CheckFailure} from './result';
+import {RuleSeverities, RuleSeveritySchema} from './severity';
+
+/**
+ * The bits of a {@linkcode CheckContext} suitable for serialization.
+ * @internal
+ */
+export interface StaticCheckContext {
+  pkgJson: PackageJson;
+  pkgJsonPath: string;
+  pkgPath: string;
+  severity: RuleSeverity;
+}
+
+/**
+ * The `fail` function that a {@linkcode RuleCheckFn} uses to create a
+ * {@linkcode CheckFailure}. The {@linkcode RuleCheckFn} then returns an array
+ * of these.
+ */
+export type CheckContextFailFn = (message: string, data?: any) => CheckFailure;
+
+/**
+ * A context object which is provided to a {@linkcode RuleCheckFn}, containing
+ * information about the current package to be checked and how to report a
+ * failure.
+ *
+ * @public
+ */
+export class CheckContext<
+  const Name extends string = string,
+  Schema extends z.ZodTypeAny = z.ZodUndefined,
+> implements StaticCheckContext
+{
+  /**
+   * The parsed `package.json` for the package being checked.
+   *
+   * _Not_ normalized.
+   */
+  public readonly pkgJson: PackageJson;
+  /**
+   * The absolute path to this context's package's `package.json`.
+   */
+  public readonly pkgJsonPath: string;
+  /**
+   * The absolute path to this context's package's root directory.
+   *
+   * This is the same as `path.dirname(pkgJsonPath)`
+   */
+  public readonly pkgPath: string;
+  /**
+   * The severity level for this rule (as chosen by the user)
+   */
+  public readonly severity: RuleSeverity;
+
+  /**
+   * The `fail` function as provided to the `Rule`'s {@linkcode RuleCheckFn}.
+   */
+  public readonly fail: CheckContextFailFn;
+
+  constructor(rule: Rule<Name, Schema>, staticCtx: StaticCheckContext) {
+    this.pkgJson = staticCtx.pkgJson;
+    this.pkgJsonPath = staticCtx.pkgJsonPath;
+    this.pkgPath = staticCtx.pkgPath;
+    this.severity = staticCtx.severity;
+    this.fail = this.createFailFn(rule);
+  }
+
+  /**
+   * Creates a `fail` function for {@linkcode RuleCheckFn}.
+   * @param rule The `Rule` which will receive the `fail` function
+   * @returns A `fail` function
+   */
+  private createFailFn(rule: Rule<Name, Schema>): CheckContextFailFn {
+    return (message, data) => ({
+      rule,
+      message,
+      data,
+      context: this,
+      failed: true,
+    });
+  }
+
+  /**
+   * Omits the {@linkcode CheckContext.pkgJson} property (too big).
+   *
+   * @returns A JSON-serializable representation of this object
+   */
+  toJSON() {
+    return {
+      pkgJsonPath: this.pkgJsonPath,
+      pkgPath: this.pkgPath,
+      severity: this.severity,
+    };
+  }
+}
+
+/**
+ * The bits of a {@linkcode RuleDef} suitable for passing the API edge
+ */
+export interface StaticRuleDef<Name extends string = string> {
+  readonly defaultSeverity?: RuleSeverity;
+  readonly description: string;
+  readonly name: Name;
+}
+
+/**
+ * The parsed and validated options for a {@linkcode Rule}.
+ */
+export type RuleOpts<Schema extends z.ZodTypeAny = z.ZodUndefined> =
+  z.infer<Schema>;
+
+/**
+ * The type _returned or fulfilled_ by the {@linkcode Rule.check} method.
+ */
+export type RuleCheckFnResult = CheckFailure[] | undefined;
+
+/**
+ * The function which actually performs the check within a {@linkcode Rule}
+ * @public
+ */
+export type RuleCheckFn<
+  Name extends string = string,
+  Schema extends z.ZodTypeAny = z.ZodUndefined,
+> = (
+  ctx: CheckContext<Name, Schema>,
+  opts?: RuleOpts<Schema>,
+) => Promise<RuleCheckFnResult> | RuleCheckFnResult;
+
+/**
+ * The raw definition of a {@linkcode Rule}, as defined by a implementor.
+ * @public
+ */
+export interface RuleDef<
+  Name extends string = string,
+  Schema extends z.ZodTypeAny = z.ZodUndefined,
+> extends StaticRuleDef<Name> {
+  /**
+   * The function which actually performs the check.
+   */
+  readonly check: RuleCheckFn<Name, Schema>;
+
+  /**
+   * Options schema for this rule, if any
+   */
+  readonly schema?: Schema;
+}
+
+/**
+ * Represents a _Rule_, which performs a check upon an installed (from tarball) package.
+ * @internal
+ */
+export class Rule<
+  const Name extends string = string,
+  Schema extends z.ZodTypeAny = z.ZodUndefined,
+> implements RuleDef<Name, Schema>
+{
+  /**
+   * The name for this rule.
+   *
+   * @todo enforce uniqueness
+   */
+  public readonly name: Name;
+  /**
+   * The description for this rule
+   */
+  public readonly description: string;
+
+  /**
+   * The default severity for this rule if not supplied by the user
+   */
+  public readonly defaultSeverity: RuleSeverity;
+
+  /**
+   * The function which actually performs the check.
+   */
+  public readonly check: RuleCheckFn<Name, Schema>;
+
+  /**
+   * The options schema for this rule, if any
+   */
+  public readonly schema: Schema;
+
+  /**
+   * A composable schema handling the default severity for this rule
+   */
+  private readonly ruleSeveritySchema: z.ZodDefault<typeof RuleSeveritySchema>;
+
+  constructor(def: RuleDef<Name, Schema>) {
+    this.name = def.name;
+    this.description = def.description;
+    this.defaultSeverity = def.defaultSeverity ?? RuleSeverities.ERROR;
+    this.check = def.check;
+    // TODO determine if this is Bad
+    this.schema = def.schema ?? (z.undefined() as Schema);
+    this.ruleSeveritySchema = RuleSeveritySchema.default(this.defaultSeverity);
+  }
+
+  /**
+   * Returns the entire schema for the value of this rule in the `RuleConfig` object.
+   */
+  get ruleSchema() {
+    return z
+      .union([
+        this.ruleSeveritySchema,
+        this.schema,
+        z.tuple([this.schema]),
+        z.tuple([this.schema, this.ruleSeveritySchema]),
+      ])
+      .optional();
+  }
+
+  /**
+   * Creates a {@linkcode RuleCont}.
+   *
+   * Wrap a {@linkcode Rule} in this function to allow it to be used in a
+   * collection of some sort.
+   */
+  toRuleCont() {
+    return <R>(
+      cont: <
+        const Name extends string,
+        Schema extends z.ZodTypeAny = z.ZodUndefined,
+      >(
+        rule: Rule<Name, Schema>,
+      ) => R,
+    ) => cont(this);
+  }
+
+  /**
+   * Returns this `Rule` in a format suitable for serialization.
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      description: this.description,
+    };
+  }
+}
+
+/**
+ * A continuation for a {@link Rule}.
+ *
+ * This devilry is an for an existential type; it allows us to iterate over a
+ * list of rules having different generic type parameters.
+ *
+ * @internal
+ * @see {@link https://jalo.website/existential-types-in-typescript-through-continuations}
+ */
+export type RuleCont = <R>(
+  cont: <
+    const Name extends string,
+    Schema extends z.ZodTypeAny = z.ZodUndefined,
+  >(
+    rule: Rule<Name, Schema>,
+  ) => R,
+) => R;
+
+/**
+ * {@linkcode Rule} factory.
+ *
+ * Rules use this to create themselves from raw {@linkcode RuleDef RuleDefs}.
+ * @param ruleDef - Raw rule definition
+ * @returns A new {@linkcode Rule}
+ */
+export function createRule<
+  const Name extends string,
+  Schema extends z.ZodTypeAny = z.ZodUndefined,
+>(ruleDef: RuleDef<Name, Schema>): Rule<Name, Schema> {
+  return new Rule(ruleDef);
+}

--- a/src/rules/severity.ts
+++ b/src/rules/severity.ts
@@ -1,0 +1,13 @@
+import {z} from 'zod';
+
+export const RuleSeverities = {
+  ERROR: 'error',
+  WARN: 'warn',
+  OFF: 'off',
+} as const;
+
+export const RuleSeveritySchema = z
+  .enum([RuleSeverities.OFF, RuleSeverities.WARN, RuleSeverities.ERROR])
+  .describe(
+    'Severity of a rule. `off` disables the rule, `warn` will warn on violations, and `error` will error on violations.',
+  );

--- a/src/smoker.ts
+++ b/src/smoker.ts
@@ -1,23 +1,47 @@
 /* eslint-disable no-labels */
+import {yellow} from 'chalk';
+import createDebug from 'debug';
 import {EventEmitter} from 'node:events';
 import fs from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import StrictEventEmitter from 'strict-event-emitter-types';
+import {z} from 'zod';
 import {SmokerError} from './error';
-import {Events, type SmokerEvents} from './events';
-import {loadPackageManagers, type PackageManager} from './pm';
+import {Events, type InstallEventData, type SmokerEvents} from './events';
+import {
+  loadPackageManagers,
+  type InstallResults,
+  type PackageManager,
+} from './pm';
+import {
+  CheckContext,
+  DEFAULT_RULE_CONFIG,
+  RuleConfigSchema,
+  type RawRuleConfig,
+  type RuleConfig,
+  type RuleCont,
+  type StaticCheckContext,
+} from './rules';
+import {BuiltinRuleConts} from './rules/builtin';
+import {
+  type CheckFailure,
+  type CheckOk,
+  type CheckResults,
+} from './rules/result';
 import type {
-  InstallEventData,
   InstallManifest,
   PkgInstallManifest,
   PkgRunManifest,
   RunManifest,
   RunScriptResult,
   SmokeOptions,
+  SmokeResults,
   SmokerOptions,
 } from './types';
-import {normalizeStringArray} from './util';
+import {normalizeStringArray, readPackageJson} from './util';
+
+const debug = createDebug('midnight-smoker:smoker');
 
 export const TMP_DIR_PREFIX = 'midnight-smoker-';
 
@@ -45,6 +69,12 @@ const {
   RUN_SCRIPT_FAILED,
   RUN_SCRIPT_OK,
   LINGERED,
+  RUN_CHECKS_BEGIN,
+  RUN_CHECKS_FAILED,
+  RUN_CHECKS_OK,
+  RUN_CHECK_BEGIN,
+  RUN_CHECK_FAILED,
+  RUN_CHECK_OK,
 } = Events;
 
 export class Smoker extends createStrictEventEmitterClass() {
@@ -81,17 +111,26 @@ export class Smoker extends createStrictEventEmitterClass() {
    */
   private readonly workspaces: string[];
 
+  public readonly ruleConfig: RuleConfig;
   /**
    * List of scripts to run in each workspace
    */
   public readonly scripts: string[];
 
+  /**
+   * Whether or not to run builtin checks
+   */
+  private readonly checks: boolean;
+
+  private readonly originalOpts: SmokerOptions;
+
   constructor(
-    scripts: string | string[],
     public readonly pms: Map<string, PackageManager>,
+    scripts: string | string[] = [],
     opts: SmokerOptions = {},
   ) {
     super();
+    this.originalOpts = opts;
     this.scripts = normalizeStringArray(scripts);
     opts = {...opts};
 
@@ -109,24 +148,30 @@ export class Smoker extends createStrictEventEmitterClass() {
         'Option "workspace" is mutually exclusive with "all" and/or "includeRoot"',
       );
     }
-
+    this.checks = opts.checks !== false;
     this.pmIds = new WeakMap();
     for (const [pmId, pm] of pms) {
       this.pmIds.set(pm, pmId);
     }
     this.tempDirs = new Set();
+    this.ruleConfig = RuleConfigSchema.parse({
+      ...DEFAULT_RULE_CONFIG,
+      ...opts.rules,
+    });
   }
 
   public static async init(
-    scripts: string | string[],
+    scripts: string | string[] = [],
     opts: SmokeOptions = {},
   ) {
     const {pm, verbose, loose, all} = opts;
+
     const pms = await loadPackageManagers(pm, {
       verbose,
       loose: all && loose,
     });
-    return new Smoker(scripts, pms, opts);
+
+    return new Smoker(pms, scripts, opts);
   }
 
   /**
@@ -135,9 +180,9 @@ export class Smoker extends createStrictEventEmitterClass() {
    * @param opts - Options
    */
   public static async smoke(
-    scripts: string | string[],
+    scripts: string | string[] = [],
     opts: SmokeOptions = {},
-  ): Promise<RunScriptResult[]> {
+  ): Promise<SmokeResults> {
     const smoker = await Smoker.init(scripts, opts);
     return smoker.smoke();
   }
@@ -192,7 +237,7 @@ export class Smoker extends createStrictEventEmitterClass() {
   /**
    * Installs from tarball in a temp dir
    */
-  public async install(manifests: PkgInstallManifest): Promise<PkgRunManifest> {
+  public async install(manifests: PkgInstallManifest): Promise<InstallResults> {
     if (!manifests?.size) {
       throw new TypeError(
         '(install) Non-empty "pkgInstallManifest" arg is required',
@@ -202,22 +247,26 @@ export class Smoker extends createStrictEventEmitterClass() {
     // ensure we emit asynchronously
     await Promise.resolve();
 
-    const installData = this.buildEventData(manifests);
+    const installData = this.buildInstallEventData(manifests);
     this.emit(INSTALL_BEGIN, installData);
 
-    const pkgRunManifest: PkgRunManifest = new Map();
-
+    const installResults: InstallResults = new Map();
     for (const [pm, manifest] of manifests) {
       try {
-        // TODO check for errors?
-        await pm.install({...manifest, additionalDeps: this.add});
-        const runManifests: Set<RunManifest> = new Set();
-        for (const packedPkg of manifest.packedPkgs) {
-          for (const script of this.scripts) {
-            runManifests.add({packedPkg, script});
-          }
-        }
-        pkgRunManifest.set(pm, runManifests);
+        const manifestWithAdds = {
+          ...manifest,
+          additionalDeps: this.add ?? [],
+        };
+        debug(
+          'Installing package(s) %O using %s',
+          [
+            ...manifestWithAdds.packedPkgs.map((p) => p.pkgName),
+            ...manifestWithAdds.additionalDeps,
+          ],
+          this.pmIds.get(pm),
+        );
+        const result = await pm.install(manifestWithAdds);
+        installResults.set(pm, [manifest, result]);
       } catch (err) {
         const error = err as SmokerError;
         this.emit(INSTALL_FAILED, error);
@@ -227,7 +276,7 @@ export class Smoker extends createStrictEventEmitterClass() {
 
     this.emit(INSTALL_OK, installData);
 
-    return pkgRunManifest;
+    return installResults;
   }
 
   /**
@@ -235,7 +284,8 @@ export class Smoker extends createStrictEventEmitterClass() {
    */
   public async pack(): Promise<PkgInstallManifest> {
     await Promise.resolve();
-    this.emit(PACK_BEGIN);
+
+    this.emit(PACK_BEGIN, {packageManagers: [...this.pms.keys()]});
 
     const manifestMap: PkgInstallManifest = new Map();
 
@@ -244,6 +294,7 @@ export class Smoker extends createStrictEventEmitterClass() {
 
       let manifest: InstallManifest;
       try {
+        debug('Packing into %s using %s', dest, this.pmIds.get(pm));
         manifest = await pm.pack(dest, {
           allWorkspaces: this.allWorkspaces,
           includeWorkspaceRoot: this.includeWorkspaceRoot,
@@ -255,8 +306,148 @@ export class Smoker extends createStrictEventEmitterClass() {
         throw err;
       }
     }
-    this.emit(PACK_OK, this.buildEventData(manifestMap));
+    this.emit(PACK_OK, this.buildInstallEventData(manifestMap));
     return manifestMap;
+  }
+
+  /**
+   * @internal
+   * @param ruleCont - Rule continuation
+   * @param pkgPath - Path to installed package
+   * @param config - Parsed rule config
+   * @returns Results of a single check
+   */
+  public async runCheck(
+    ruleCont: RuleCont,
+    pkgPath: string,
+    config: RawRuleConfig,
+  ): Promise<CheckResults> {
+    return ruleCont(async (rule) => {
+      let {name: ruleName, defaultSeverity: severity, schema} = rule;
+      const configForRule = config[ruleName as keyof typeof config];
+
+      let opts: z.infer<typeof schema> | undefined;
+      if (typeof configForRule === 'string') {
+        severity = configForRule;
+      } else if (Array.isArray(configForRule)) {
+        opts = configForRule[0];
+        severity = (configForRule[1] as typeof severity) ?? severity;
+      } else {
+        opts = configForRule;
+      }
+
+      const {packageJson: pkgJson, path: pkgJsonPath} = await readPackageJson({
+        cwd: pkgPath,
+        strict: true,
+      });
+
+      const staticCtx: StaticCheckContext = {
+        pkgJson,
+        pkgJsonPath,
+        pkgPath,
+        severity,
+      };
+
+      debug(`Running rule %s with context %O`, ruleName, staticCtx);
+      const context = new CheckContext(rule, staticCtx);
+
+      let result: CheckFailure[] | undefined;
+      try {
+        result = await rule.check(context, opts);
+      } catch (err) {
+        console.error(yellow(`Warning: error running rule ${ruleName}:`));
+        console.error(err);
+      }
+
+      if (result?.length) {
+        return {
+          failed: result,
+          passed: [],
+        };
+      }
+      const ok: CheckOk = {
+        rule,
+        context,
+        failed: false,
+      };
+      return {failed: [], passed: [ok]};
+    });
+  }
+
+  public async runChecks(
+    installResults: InstallResults,
+  ): Promise<CheckResults> {
+    const allFailed: CheckFailure[] = [];
+    const allPassed: CheckOk[] = [];
+    const {ruleConfig} = this;
+    await Promise.resolve();
+
+    const runnableRules = BuiltinRuleConts.filter((ruleCont) =>
+      ruleCont((rule) => ruleConfig.isRuleEnabled(rule.name)),
+    );
+
+    const total = runnableRules.length;
+    let current = 0;
+
+    this.emit(RUN_CHECKS_BEGIN, {config: ruleConfig, total});
+
+    // run against multiple package managers??
+    for (const ruleCont of runnableRules) {
+      const ruleName = ruleCont((rule) => rule.name);
+      const configForRule = ruleConfig[ruleName as keyof RawRuleConfig];
+      this.emit(RUN_CHECK_BEGIN, {
+        rule: ruleName,
+        config: configForRule,
+        current,
+        total,
+      });
+
+      for (const [{packedPkgs}] of installResults.values()) {
+        for (const {installPath: pkgPath} of packedPkgs) {
+          const {failed, passed} = await this.runCheck(
+            ruleCont,
+            pkgPath,
+            ruleConfig,
+          );
+          if (failed.length) {
+            this.emit(RUN_CHECK_FAILED, {
+              rule: ruleName,
+              config: configForRule,
+              current,
+              total,
+              failed,
+            });
+          } else {
+            this.emit(RUN_CHECK_OK, {
+              rule: ruleName,
+              config: configForRule,
+              current,
+              total,
+            });
+          }
+
+          allFailed.push(...failed);
+          allPassed.push(...passed);
+
+          current++;
+        }
+      }
+    }
+
+    const evtData = {
+      config: ruleConfig,
+      total,
+      passed: allPassed,
+      failed: allFailed,
+    };
+
+    if (allFailed.length) {
+      this.emit(RUN_CHECKS_FAILED, evtData);
+    } else {
+      this.emit(RUN_CHECKS_OK, evtData);
+    }
+
+    return {failed: allFailed, passed: allPassed};
   }
 
   /**
@@ -309,10 +500,11 @@ export class Smoker extends createStrictEventEmitterClass() {
       for await (const runManifest of runManifests) {
         let result: RunScriptResult;
         const {script} = runManifest;
+        const {pkgName} = runManifest.packedPkg;
         scripts.push(script);
         this.emit(RUN_SCRIPT_BEGIN, {
           script,
-          pkgName: runManifest.packedPkg.pkgName,
+          pkgName,
           total: totalScripts,
           current,
         });
@@ -320,6 +512,12 @@ export class Smoker extends createStrictEventEmitterClass() {
           result = await pm.runScript(runManifest);
           results.push(result);
           if (result.error) {
+            debug(
+              'Script "%s" failed in package "%s": %O',
+              script,
+              pkgName,
+              result,
+            );
             this.emit(RUN_SCRIPT_FAILED, {
               ...result,
               script,
@@ -347,45 +545,97 @@ export class Smoker extends createStrictEventEmitterClass() {
       }
     }
 
-    const failureCount = results.filter((result) => result.error).length;
+    const failed = results.filter((result) => result.error).length;
+    const passed = results.length - failed;
 
-    if (failureCount) {
-      this.emit(RUN_SCRIPTS_FAILED, {
-        results,
-        manifest: pkgRunManifestForEmit,
-        total: totalScripts,
-        failures: failureCount,
-        executed: results.length,
-      });
-    } else {
-      this.emit(RUN_SCRIPTS_OK, {
-        failures: 0,
-        results,
-        manifest: pkgRunManifestForEmit,
-        total: totalScripts,
-        executed: results.length,
-      });
-    }
+    this.emit(failed ? RUN_SCRIPTS_FAILED : RUN_SCRIPTS_OK, {
+      results,
+      manifest: pkgRunManifestForEmit,
+      total: totalScripts,
+      failed,
+      passed,
+    });
+
     return results;
   }
 
-  public async smoke(): Promise<RunScriptResult[]> {
+  /**
+   * Converts install results to a {@linkcode PkgRunManifest} for {@linkcode runScripts}
+   * @param installResults Results of {@linkcode install}
+   * @returns Package managers and scripts to run for each unpacked package
+   */
+  private buildPkgRunManifest(installResults: InstallResults): PkgRunManifest {
+    const pkgRunManifest: PkgRunManifest = new Map();
+    for (const [pm, [{packedPkgs}]] of installResults) {
+      const runManifests: Set<RunManifest> = new Set();
+      for (const packedPkg of packedPkgs) {
+        for (const script of this.scripts) {
+          runManifests.add({
+            script,
+            packedPkg,
+          });
+        }
+      }
+      pkgRunManifest.set(pm, runManifests);
+    }
+    return pkgRunManifest;
+  }
+
+  /**
+   * Returns `true` if any of the scripts failed or any of the checks failed
+   * @param results Results from {@linkcode smoke}
+   * @returns Whether the results indicate a failure
+   */
+  public isSmokeFailure({scripts, checks}: SmokeResults) {
+    return checks.failed.length || scripts.some((r) => r.error);
+  }
+
+  /**
+   * Pack, install, run checks (optionally), and run scripts (optionally)
+   * @returns Results
+   */
+  public async smoke(): Promise<SmokeResults> {
     // do not emit synchronously
     await Promise.resolve();
     this.emit(SMOKE_BEGIN);
 
     try {
+      // PACK
       const pkgInstallManifest = await this.pack();
-      const pkgRunManifest = await this.install(pkgInstallManifest);
-      const results = await this.runScripts(pkgRunManifest);
-      if (!results.some((result) => result.error)) {
-        this.emit(SMOKE_OK);
-      } else {
-        this.emit(SMOKE_FAILED, new SmokerError('🤮 Maurice!'));
+
+      // INSTALL
+      const installResults = await this.install(pkgInstallManifest);
+
+      let ruleResults: CheckResults = {passed: [], failed: []};
+      let runScriptResults: RunScriptResult[] = [];
+
+      // RUN CHECKS
+      if (this.checks) {
+        ruleResults = await this.runChecks(installResults);
       }
-      return results;
+
+      // RUN SCRIPTS
+      if (this.scripts.length) {
+        const pkgRunManifest = this.buildPkgRunManifest(installResults);
+        runScriptResults = await this.runScripts(pkgRunManifest);
+      }
+
+      // END
+      const smokeResults: SmokeResults = {
+        scripts: runScriptResults,
+        checks: ruleResults,
+        opts: this.originalOpts,
+      };
+
+      if (this.isSmokeFailure(smokeResults)) {
+        this.emit(SMOKE_FAILED, new SmokerError('🤮 Maurice!'));
+      } else {
+        this.emit(SMOKE_OK, smokeResults);
+      }
+
+      return smokeResults;
     } catch (err) {
-      this.emit(SMOKE_FAILED, err as Error);
+      this.emit(SMOKE_FAILED, err as SmokerError);
       throw err;
     } finally {
       await this.cleanup();
@@ -399,7 +649,7 @@ export class Smoker extends createStrictEventEmitterClass() {
    * @param pkgInstallManifest What to install and with what package manager
    * @returns Something to be emitted
    */
-  private buildEventData(
+  private buildInstallEventData(
     pkgInstallManifest: PkgInstallManifest,
   ): InstallEventData {
     const uniquePkgs = new Set<string>();

--- a/test/e2e/config-file.spec.ts
+++ b/test/e2e/config-file.spec.ts
@@ -11,11 +11,19 @@ describe('midnight-smoker', function () {
       const cwd = path.join(__dirname, 'fixture', 'config-esm');
 
       it('should respect the config file', async function () {
-        const {stdout} = await execSmoker(['smoke', '--json'], {cwd});
+        const {stdout} = await execSmoker(['smoke', '--json', '--no-checks'], {
+          cwd,
+        });
         const result = JSON.parse(stdout);
         expect(result, 'to satisfy', {
-          results: expect.it('to have length', 2),
-          manifest: expect.it('to have keys satisfying', /^(npm|yarn)/),
+          results: {
+            scripts: expect
+              .it('to have length', 2)
+              .and('to satisfy', [
+                {rawResult: {command: /npm/}},
+                {rawResult: {command: /yarn/}},
+              ]),
+          },
         });
       });
     });
@@ -24,19 +32,24 @@ describe('midnight-smoker', function () {
       const cwd = path.join(__dirname, 'fixture', 'config-script');
 
       it('should run script from config file', async function () {
-        const {stdout} = await execSmoker([], {cwd});
+        // includes json: true
+        const {stdout} = await execSmoker(['--no-checks'], {cwd});
         const result = JSON.parse(stdout);
         expect(result, 'to satisfy', {
-          results: expect.it('to have length', 1),
+          results: {
+            scripts: expect.it('to have length', 1),
+          },
         });
       });
 
       describe('when the CLI also contains a script', function () {
         it('should run all scripts', async function () {
-          const {stdout} = await execSmoker(['smoke'], {cwd});
+          const {stdout} = await execSmoker(['smoke', '--no-checks'], {cwd});
           const result = JSON.parse(stdout);
           expect(result, 'to satisfy', {
-            results: expect.it('to have length', 2),
+            results: {
+              scripts: expect.it('to have length', 2),
+            },
           });
         });
       });
@@ -46,19 +59,23 @@ describe('midnight-smoker', function () {
       const cwd = path.join(__dirname, 'fixture', 'config-scripts');
 
       it('should run scripts from config file', async function () {
-        const {stdout} = await execSmoker([], {cwd});
+        const {stdout} = await execSmoker(['--no-checks'], {cwd});
         const result = JSON.parse(stdout);
         expect(result, 'to satisfy', {
-          results: expect.it('to have length', 1),
+          results: {
+            scripts: expect.it('to have length', 1),
+          },
         });
       });
 
       describe('when the CLI also contains a script', function () {
         it('should run all scripts', async function () {
-          const {stdout} = await execSmoker(['smoke'], {cwd});
+          const {stdout} = await execSmoker(['smoke', '--no-checks'], {cwd});
           const result = JSON.parse(stdout);
           expect(result, 'to satisfy', {
-            results: expect.it('to have length', 2),
+            results: {
+              scripts: expect.it('to have length', 2),
+            },
           });
         });
       });

--- a/test/e2e/fixture/single-script/index.js
+++ b/test/e2e/fixture/single-script/index.js
@@ -1,0 +1,1 @@
+console.log('entry point');

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -2,10 +2,11 @@
  * E2E test harness helpers
  * @module
  */
-import {node as execa, type ExecaReturnValue, type NodeOptions} from 'execa';
+import createDebug from 'debug';
+import {node as execa, type NodeOptions} from 'execa';
 import path from 'node:path';
 import {inspect} from 'node:util';
-import createDebug from 'debug';
+import type {RawRunScriptResult} from '../../src';
 
 const debug = createDebug('midnight-smoker:test:e2e');
 
@@ -21,7 +22,7 @@ export const CLI_PATH = path.join(CWD, 'bin', 'smoker.js');
 export async function execSmoker(
   args: string[],
   opts: NodeOptions = {},
-): Promise<ExecaReturnValue> {
+): Promise<RawRunScriptResult> {
   debug(`executing: ${CLI_PATH} ${args.join(' ')}`);
   return execa(CLI_PATH, args, {
     cwd: CWD,
@@ -62,7 +63,8 @@ export function fixupOutput(stdout: string, stripPmVersions = true) {
       /"tarballFilepath":\s+"[^"]+"/g,
       '"tarballFilepath": "<tarball.tgz>"',
     )
-    .replace(/"installPath":\s+"[^"]+"/g, '"installPath": "<some/path>"');
+    .replace(/"(install|pkg(Json)?)Path":\s+"[^"]+"/g, '"$1": "<some/path>"')
+    .replace(/\(.+?:\d+:\d+\)/g, '(<path/to/file>:<line>:<col>)');
 
   if (stripPmVersions) {
     result = result.replace(

--- a/test/e2e/rules/fixture/no-banned-files-cfg/id_rsa
+++ b/test/e2e/rules/fixture/no-banned-files-cfg/id_rsa
@@ -1,0 +1,1 @@
+I am a private key

--- a/test/e2e/rules/fixture/no-banned-files-cfg/package.json
+++ b/test/e2e/rules/fixture/no-banned-files-cfg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-banned-files",
+  "version": "1.0.0",
+  "smoker": {
+    "rules": {
+      "no-banned-files": [{"allow": "id_rsa", "deny": "anarchist-cookbook.txt"}, "error"]
+    }
+  }
+}

--- a/test/e2e/rules/fixture/no-banned-files/id_rsa
+++ b/test/e2e/rules/fixture/no-banned-files/id_rsa
@@ -1,0 +1,1 @@
+I am a private key

--- a/test/e2e/rules/fixture/no-banned-files/package.json
+++ b/test/e2e/rules/fixture/no-banned-files/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "no-banned-files",
+  "version": "1.0.0"
+}

--- a/test/e2e/rules/fixture/no-missing-entry-point-esm/package.json
+++ b/test/e2e/rules/fixture/no-missing-entry-point-esm/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-missing-entry-point-esm",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-entry-point-node-resolution-ok/index.js
+++ b/test/e2e/rules/fixture/no-missing-entry-point-node-resolution-ok/index.js
@@ -1,0 +1,1 @@
+console.log('moooo');

--- a/test/e2e/rules/fixture/no-missing-entry-point-node-resolution-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-entry-point-node-resolution-ok/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "no-missing-entry-point",
+  "version": "1.0.0"
+}

--- a/test/e2e/rules/fixture/no-missing-entry-point-node-resolution/package.json
+++ b/test/e2e/rules/fixture/no-missing-entry-point-node-resolution/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "no-missing-entry-point",
+  "version": "1.0.0"
+}

--- a/test/e2e/rules/fixture/no-missing-entry-point-ok/index.js
+++ b/test/e2e/rules/fixture/no-missing-entry-point-ok/index.js
@@ -1,0 +1,1 @@
+console.log('moooo');

--- a/test/e2e/rules/fixture/no-missing-entry-point-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-entry-point-ok/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-missing-entry-point-ok",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/e2e/rules/fixture/no-missing-entry-point/package.json
+++ b/test/e2e/rules/fixture/no-missing-entry-point/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-missing-entry-point",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-conditional-ok/index-missing.cjs
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional-ok/index-missing.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/e2e/rules/fixture/no-missing-exports-conditional-ok/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional-ok/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-conditional-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional-ok/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-conditional",
+  "version": "1.0.0",
+  "exports": {
+    "require": "./index-missing.cjs",
+    "default": "./index.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-conditional/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-conditional/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-conditional",
+  "version": "1.0.0",
+  "exports": {
+    "require": "./index-missing.js",
+    "default": "./index.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-default/index-missing.cjs
+++ b/test/e2e/rules/fixture/no-missing-exports-default/index-missing.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/e2e/rules/fixture/no-missing-exports-default/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-default/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-default/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-default/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-default",
+  "version": "1.0.0",
+  "exports": {
+    "default": "./index.js",
+    "require": "./index-missing.cjs"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-glob-ok/lib/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-glob-ok/lib/index.js
@@ -1,0 +1,1 @@
+console.log('moooo');

--- a/test/e2e/rules/fixture/no-missing-exports-glob-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-glob-ok/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-glob-ok",
+  "version": "1.0.0",
+  "exports": {
+    "./*.js": "./lib/*.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-glob/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-glob/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-glob",
+  "version": "1.0.0",
+  "exports": {
+    "./*.js": "./lib/*.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-import/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-import/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-import/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-import",
+  "version": "1.0.0",
+  "exports": {
+    "import": "./index.js"
+  },
+  "type": "commonjs"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-main-export-ok/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-main-export-ok/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-main-export-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-main-export-ok/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "no-missing-exports-no-exports",
+  "version": "1.0.0",
+  "exports": "./index.js",
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-main-export/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-main-export/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "no-missing-exports-no-exports",
+  "version": "1.0.0",
+  "exports": "./index.js",
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-no-exports/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-no-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-missing-exports-no-exports",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-no-glob/lib/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-no-glob/lib/index.js
@@ -1,0 +1,1 @@
+console.log('moooo');

--- a/test/e2e/rules/fixture/no-missing-exports-no-glob/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-no-glob/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-no-glob",
+  "version": "1.0.0",
+  "exports": {
+    "./*.js": "./lib/*.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-require/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-require/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-require/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-require/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-require",
+  "version": "1.0.0",
+  "exports": {
+    "require": "./index.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-ok/index-missing.js
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-ok/index-missing.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-ok/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-ok/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-ok/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-subpath-ok",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./missing.js": "./index-missing.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-subpath/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-subpath/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-subpath",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./missing.js": "./index-missing.js"
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-types/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-types/index.js
@@ -1,0 +1,1 @@
+console.log('moooo?');

--- a/test/e2e/rules/fixture/no-missing-exports-types/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-types/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-missing-exports-types",
+  "version": "1.0.0",
+  "exports": {
+    "require": "./index.js",
+    "types": "./index.js"
+  }
+}

--- a/test/e2e/rules/fixture/no-missing-pkg-files-ok/bin/no-missing-pkg-files.js
+++ b/test/e2e/rules/fixture/no-missing-pkg-files-ok/bin/no-missing-pkg-files.js
@@ -1,0 +1,1 @@
+console.log('not missing');

--- a/test/e2e/rules/fixture/no-missing-pkg-files-ok/package.json
+++ b/test/e2e/rules/fixture/no-missing-pkg-files-ok/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "no-missing-pkg-files-ok",
+  "version": "1.0.0",
+  "bin": {
+    "no-missing-pkg-files": "./bin/no-missing-pkg-files.js"
+  }
+}

--- a/test/e2e/rules/fixture/no-missing-pkg-files-string-bin/package.json
+++ b/test/e2e/rules/fixture/no-missing-pkg-files-string-bin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-missing-pkg-files-string",
+  "version": "1.0.0",
+  "bin": "./bin/no-missing-pkg-files.js"
+}

--- a/test/e2e/rules/fixture/no-missing-pkg-files/package.json
+++ b/test/e2e/rules/fixture/no-missing-pkg-files/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "no-missing-pkg-files",
+  "version": "1.0.0",
+  "bin": {
+    "no-missing-pkg-files": "./bin/no-missing-pkg-files.js"
+  }
+}

--- a/test/e2e/rules/no-banned-files.spec.ts
+++ b/test/e2e/rules/no-banned-files.spec.ts
@@ -1,0 +1,80 @@
+import unexpected from 'unexpected';
+import type {PackedPackage} from '../../../src';
+import {RuleSeverities, type RawRuleConfig} from '../../../src/rules';
+import noBannedFiles from '../../../src/rules/builtin/no-banned-files';
+import {setupRuleTest, applyRules} from './rule-helpers';
+
+const expect = unexpected.clone();
+
+describe('midnight-smoker', function () {
+  describe('rules', function () {
+    let ruleConfig: RawRuleConfig;
+    let pkg: PackedPackage;
+
+    describe('no-banned-files', function () {
+      const ruleCont = noBannedFiles.toRuleCont();
+
+      describe('when the package contains a banned file', function () {
+        describe('when the file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-banned-files'));
+          });
+
+          it('should return a RuleFailure for each banned file', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to satisfy', [
+                  {
+                    rule: noBannedFiles.toJSON(),
+                    message: 'Banned file found: id_rsa (Private SSH key)',
+                    context: {
+                      pkgJson: expect.it('to be an object'),
+                      pkgJsonPath: expect.it('to be a string'),
+                      pkgPath: expect.it('to be a string'),
+                      severity: RuleSeverities.ERROR,
+                    },
+                  },
+                ]),
+              },
+            );
+          });
+        });
+      });
+
+      describe('with config', function () {
+        beforeEach(function () {
+          ({ruleConfig, pkg} = setupRuleTest('no-banned-files-cfg', {
+            'no-banned-files': {
+              deny: ['anarchist-cookbook.txt'],
+              allow: ['id_rsa'],
+            },
+          }));
+        });
+
+        it('should allow additional files to be banned', async function () {
+          await expect(
+            applyRules(ruleConfig, pkg, ruleCont),
+            'to be fulfilled with value satisfying',
+            {
+              failed: expect.it('to satisfy', [
+                {
+                  rule: noBannedFiles.toJSON(),
+                  message:
+                    'Banned file found: anarchist-cookbook.txt (per custom deny list)',
+                  context: {
+                    pkgJson: expect.it('to be an object'),
+                    pkgJsonPath: expect.it('to be a string'),
+                    pkgPath: expect.it('to be a string'),
+                    severity: RuleSeverities.ERROR,
+                  },
+                },
+              ]),
+            },
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/rules/no-missing-entry-point.spec.ts
+++ b/test/e2e/rules/no-missing-entry-point.spec.ts
@@ -1,0 +1,137 @@
+import unexpected from 'unexpected';
+import type {PackedPackage} from '../../../src';
+import {RuleSeverities, type RawRuleConfig} from '../../../src/rules';
+import noMissingEntryPoint from '../../../src/rules/builtin/no-missing-entry-point';
+import {setupRuleTest, applyRules} from './rule-helpers';
+
+const expect = unexpected.clone();
+
+describe('midnight-smoker', function () {
+  describe('rules', function () {
+    let ruleConfig: RawRuleConfig;
+    let pkg: PackedPackage;
+
+    describe('no-missing-entry-point', function () {
+      const ruleCont = noMissingEntryPoint.toRuleCont();
+
+      describe('when the package is an ESM package', function () {
+        beforeEach(function () {
+          ({ruleConfig, pkg} = setupRuleTest('no-missing-entry-point-esm'));
+        });
+
+        it('should not return a RuleFailure', async function () {
+          await expect(
+            applyRules(ruleConfig, pkg, ruleCont),
+            'to be fulfilled with value satisfying',
+            {
+              passed: [
+                {
+                  rule: noMissingEntryPoint.toJSON(),
+                  context: {
+                    pkgJson: expect.it('to be an object'),
+                    pkgJsonPath: expect.it('to be a string'),
+                    pkgPath: expect.it('to be a string'),
+                    severity: RuleSeverities.ERROR,
+                  },
+                },
+              ],
+              failed: expect.it('to be empty'),
+            },
+          );
+        });
+      });
+
+      describe('when the package has a "main" field', function () {
+        describe('when the file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-missing-entry-point'));
+          });
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: [
+                  {
+                    rule: noMissingEntryPoint.toJSON(),
+                    message:
+                      'No entry point found for package "no-missing-entry-point"; file from field "main" unreadable at path: index.js',
+                    context: {
+                      pkgJson: expect.it('to be an object'),
+                      pkgJsonPath: expect.it('to be a string'),
+                      pkgPath: expect.it('to be a string'),
+                      severity: RuleSeverities.ERROR,
+                    },
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when the file exists', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-missing-entry-point-ok'));
+          });
+          it('should not return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to be empty'),
+              },
+            );
+          });
+        });
+      });
+
+      describe('when the package has no "main" field', function () {
+        describe('when the file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-entry-point-node-resolution',
+            ));
+          });
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: [
+                  {
+                    rule: noMissingEntryPoint.toJSON(),
+                    message:
+                      'No entry point found for package "no-missing-entry-point"; (index.js, index.json or index.node)',
+                    context: {
+                      pkgJson: expect.it('to be an object'),
+                      pkgJsonPath: expect.it('to be a string'),
+                      pkgPath: expect.it('to be a string'),
+                      severity: RuleSeverities.ERROR,
+                    },
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when the file exists', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-entry-point-node-resolution-ok',
+            ));
+          });
+          it('should not return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to be empty'),
+              },
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/rules/no-missing-exports.spec.ts
+++ b/test/e2e/rules/no-missing-exports.spec.ts
@@ -1,0 +1,368 @@
+import unexpected from 'unexpected';
+import type {PackedPackage} from '../../../src';
+import {RuleSeverities, type RawRuleConfig} from '../../../src/rules';
+import noMissingExports from '../../../src/rules/builtin/no-missing-exports';
+import {setupRuleTest, applyRules} from './rule-helpers';
+
+const expect = unexpected.clone();
+
+describe('midnight-smoker', function () {
+  describe('rules', function () {
+    let ruleConfig: RawRuleConfig;
+    let pkg: PackedPackage;
+
+    describe('no-missing-exports', function () {
+      const ruleCont = noMissingExports.toRuleCont();
+
+      describe('when the package contains no "exports" field', function () {
+        beforeEach(function () {
+          ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-no-exports'));
+        });
+
+        it('should not return a RuleFailure', async function () {
+          await expect(
+            applyRules(ruleConfig, pkg, ruleCont),
+            'to be fulfilled with value satisfying',
+            {
+              passed: [
+                {
+                  rule: noMissingExports.toJSON(),
+                  context: {
+                    pkgJson: expect.it('to be an object'),
+                    pkgJsonPath: expect.it('to be a string'),
+                    pkgPath: expect.it('to be a string'),
+                    severity: RuleSeverities.ERROR,
+                  },
+                },
+              ],
+              failed: expect.it('to be empty'),
+            },
+          );
+        });
+      });
+
+      describe('when the package contains a string "exports" field', function () {
+        describe('when the file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-main-export',
+            ));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                passed: expect.it('to be empty'),
+                failed: [
+                  {
+                    rule: noMissingExports.toJSON(),
+                    message: 'Export unreadable at path: ./index.js',
+                    failed: true,
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when the file is present', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-main-export-ok',
+            ));
+          });
+
+          it('should not return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to be empty'),
+              },
+            );
+          });
+        });
+      });
+
+      describe('when the package contains subpath "exports"', function () {
+        describe('when a file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-subpath'));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                passed: expect.it('to be empty'),
+                failed: [
+                  {
+                    rule: noMissingExports.toJSON(),
+                    message:
+                      'Export "./missing.js" unreadable at path: ./index-missing.js',
+                    failed: true,
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when no files are missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-subpath-ok',
+            ));
+          });
+
+          it('should not return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to be empty'),
+              },
+            );
+          });
+        });
+
+        describe('when a glob pattern is present', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-glob'));
+          });
+
+          describe('when all files are missing', function () {
+            it('should return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  failed: [
+                    {
+                      message:
+                        'Export "./*.js" matches no files using glob: ./lib/*.js',
+                    },
+                  ],
+                  passed: expect.it('to be empty'),
+                },
+              );
+            });
+          });
+
+          describe('when at least one file matches the glob pattern', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-glob-ok'));
+            });
+
+            it('should not return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  failed: expect.it('to be empty'),
+                },
+              );
+            });
+          });
+
+          describe('when glob patterns are disallowed', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-no-glob', {
+                'no-missing-exports': {
+                  glob: false,
+                },
+              }));
+            });
+
+            it('should return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  failed: [
+                    {
+                      message: 'Export "./*.js" contains a glob pattern',
+                    },
+                  ],
+                  passed: expect.it('to be empty'),
+                },
+              );
+            });
+          });
+        });
+      });
+
+      describe('when the package contains conditional "exports"', function () {
+        describe('when a file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-conditional',
+            ));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                passed: expect.it('to be empty'),
+                failed: [
+                  {
+                    rule: noMissingExports.toJSON(),
+                    message:
+                      'Export "require" unreadable at path: ./index-missing.js',
+                    failed: true,
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when no files are missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-conditional-ok',
+            ));
+          });
+
+          it('should not return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: expect.it('to be empty'),
+              },
+            );
+          });
+
+          describe('when a "require" export is present', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-require'));
+            });
+
+            describe('when the file is ESM', function () {
+              it('should return a RuleFailure', async function () {
+                await expect(
+                  applyRules(ruleConfig, pkg, ruleCont),
+                  'to be fulfilled with value satisfying',
+                  {
+                    passed: expect.it('to be empty'),
+                    failed: [
+                      {
+                        rule: noMissingExports.toJSON(),
+                        message:
+                          'Expected export "require" to be a CJS script at path: ./index.js',
+                        failed: true,
+                      },
+                    ],
+                  },
+                );
+              });
+            });
+          });
+
+          describe('when an "import" export is present', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-import'));
+            });
+
+            describe('when the file is not ESM', function () {
+              it('should return a RuleFailure', async function () {
+                await expect(
+                  applyRules(ruleConfig, pkg, ruleCont),
+                  'to be fulfilled with value satisfying',
+                  {
+                    passed: expect.it('to be empty'),
+                    failed: [
+                      {
+                        rule: noMissingExports.toJSON(),
+                        message:
+                          'Expected export "import" to be an ESM module at path: ./index.js',
+                        failed: true,
+                      },
+                    ],
+                  },
+                );
+              });
+            });
+          });
+
+          describe('when an "types" export is present', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-types'));
+            });
+
+            describe('when the file does not have a .d.ts extension', function () {
+              it('should return a RuleFailure', async function () {
+                await expect(
+                  applyRules(ruleConfig, pkg, ruleCont),
+                  'to be fulfilled with value satisfying',
+                  {
+                    passed: expect.it('to be empty'),
+                    failed: [
+                      {
+                        rule: noMissingExports.toJSON(),
+                        message:
+                          'Expected export "types" to be a .d.ts file at path: ./index.js',
+                        failed: true,
+                      },
+                    ],
+                  },
+                );
+              });
+            });
+          });
+
+          describe('when a "default" export is present', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-default'));
+            });
+
+            describe('when it does not appear last in the "exports" obejct', function () {
+              it('should return a RuleFailure', async function () {
+                await expect(
+                  applyRules(ruleConfig, pkg, ruleCont),
+                  'to be fulfilled with value satisfying',
+                  {
+                    passed: expect.it('to be empty'),
+                    failed: [
+                      {
+                        rule: noMissingExports.toJSON(),
+                        message:
+                          'Conditional export "default" must be the last export',
+                        failed: true,
+                      },
+                    ],
+                  },
+                );
+              });
+            });
+
+            describe('when the "order" option is disabled', function () {
+              beforeEach(function () {
+                ({ruleConfig, pkg} = setupRuleTest(
+                  'no-missing-exports-default',
+                  {'no-missing-exports': {order: false}},
+                ));
+              });
+
+              it('should not return a RuleFailure', async function () {
+                await expect(
+                  applyRules(ruleConfig, pkg, ruleCont),
+                  'to be fulfilled with value satisfying',
+                  {
+                    failed: expect.it('to be empty'),
+                  },
+                );
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/rules/no-missing-pkg-files.spec.ts
+++ b/test/e2e/rules/no-missing-pkg-files.spec.ts
@@ -1,0 +1,127 @@
+import unexpected from 'unexpected';
+import type {PackedPackage} from '../../../src';
+import {RuleSeverities, type RawRuleConfig} from '../../../src/rules';
+import noMissingPkgFiles from '../../../src/rules/builtin/no-missing-pkg-files';
+import {setupRuleTest, applyRules} from './rule-helpers';
+
+const expect = unexpected.clone();
+
+describe('midnight-smoker', function () {
+  describe('rules', function () {
+    let ruleConfig: RawRuleConfig;
+    let pkg: PackedPackage;
+
+    describe('no-missing-pkg-files', function () {
+      const ruleCont = noMissingPkgFiles.toRuleCont();
+
+      describe('when run without options', function () {
+        describe('when the "bin" field is an object', function () {
+          describe('when the file is missing', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-pkg-files'));
+            });
+
+            it('should return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  failed: [
+                    {
+                      rule: noMissingPkgFiles.toJSON(),
+                      message:
+                        'File "no-missing-pkg-files" from "bin" field unreadable at path: ./bin/no-missing-pkg-files.js',
+                      context: {
+                        pkgJson: expect.it('to be an object'),
+                        pkgJsonPath: expect.it('to be a string'),
+                        pkgPath: expect.it('to be a string'),
+                        severity: RuleSeverities.ERROR,
+                      },
+                    },
+                  ],
+                },
+              );
+            });
+          });
+
+          describe('when the file is present', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-pkg-files-ok'));
+            });
+
+            it('should not return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  passed: [
+                    {
+                      rule: noMissingPkgFiles.toJSON(),
+                      context: {
+                        pkgJson: expect.it('to be an object'),
+                        pkgJsonPath: expect.it('to be a string'),
+                        pkgPath: expect.it('to be a string'),
+                        severity: RuleSeverities.ERROR,
+                      },
+                    },
+                  ],
+                },
+              );
+            });
+          });
+        });
+        describe('when the "bin" field is a string', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-pkg-files-string-bin',
+            ));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                failed: [
+                  {
+                    rule: noMissingPkgFiles.toJSON(),
+                    message:
+                      'File from "bin" field unreadable at path: ./bin/no-missing-pkg-files.js',
+                    context: {
+                      pkgJson: expect.it('to be an object'),
+                      pkgJsonPath: expect.it('to be a string'),
+                      pkgPath: expect.it('to be a string'),
+                      severity: RuleSeverities.ERROR,
+                    },
+                  },
+                ],
+              },
+            );
+          });
+        });
+      });
+
+      describe('when run with options', function () {
+        describe('when "bin" is set to false', function () {
+          describe('when the file is missing', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest('no-missing-pkg-files', {
+                'no-missing-pkg-files': {bin: false},
+              }));
+            });
+
+            it('should return no RuleFailures', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  failed: expect.it('to be empty'),
+                },
+              );
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/rules/rule-helpers.ts
+++ b/test/e2e/rules/rule-helpers.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import {PackedPackage, Smoker} from '../../../src';
+import {RawRuleConfig} from '../../../src/rules/rule-config';
+import {RuleCont} from '../../../src/rules/rule';
+import {EventEmitter} from 'node:events';
+import {BuiltinRuleConts} from '../../../src/rules/builtin';
+
+export function setupRuleTest(fixtureName: string, config: RawRuleConfig = {}) {
+  const ruleConfig = config;
+  const installPath = path.join(__dirname, 'fixture', fixtureName);
+  try {
+    fs.statSync(installPath);
+  } catch {
+    throw new Error(`Fixture "${fixtureName}" not found`);
+  }
+  const pkg: PackedPackage = {
+    pkgName: '',
+    installPath,
+    tarballFilepath: '',
+  };
+  return {ruleConfig, pkg};
+}
+
+export async function applyRules(
+  config: RawRuleConfig,
+  {installPath: pkgPath}: PackedPackage,
+  ruleCont: RuleCont,
+) {
+  return Smoker.prototype.runCheck.call(
+    new EventEmitter(),
+    ruleCont,
+    pkgPath,
+    config,
+  );
+}

--- a/test/unit/pm/loader.spec.ts
+++ b/test/unit/pm/loader.spec.ts
@@ -1,7 +1,7 @@
 import {parse} from 'semver';
 import rewiremock from 'rewiremock/node';
 import unexpected from 'unexpected';
-import type {initLoader as _initLoader} from '../../../src/pm/loader';
+import type {initPMLoader as _initPMLoader} from '../../../src/pm/pm-loader';
 import type {normalizeVersion as _normalizeVersion} from '../../../src/pm/version';
 import {createSandbox} from 'sinon';
 import {NullPm, nullPmModule} from '../mocks';
@@ -12,7 +12,7 @@ describe('midnight-smoker', function () {
   describe('package manager', function () {
     describe('loader', function () {
       let sandbox: sinon.SinonSandbox;
-      let initLoader: typeof _initLoader;
+      let initPMLoader: typeof _initPMLoader;
       let versionStub: {
         normalizeVersion: sinon.SinonStubbedMember<typeof _normalizeVersion>;
       };
@@ -23,8 +23,8 @@ describe('midnight-smoker', function () {
           normalizeVersion: sandbox.stub<[string, string?]>().resolvesArg(1),
         };
 
-        ({initLoader} = rewiremock.proxy(
-          () => require('../../../src/pm/loader'),
+        ({initPMLoader} = rewiremock.proxy(
+          () => require('../../../src/pm/pm-loader'),
           {
             '../../../src/pm/version': versionStub,
           },
@@ -37,14 +37,14 @@ describe('midnight-smoker', function () {
 
       describe('initLoader()', function () {
         it('should return a function', function () {
-          expect(initLoader(), 'to be a function');
+          expect(initPMLoader(), 'to be a function');
         });
 
         describe('loadPackageManagers()', function () {
-          let loadPackageManagers: ReturnType<typeof initLoader>;
+          let loadPackageManagers: ReturnType<typeof initPMLoader>;
 
           beforeEach(function () {
-            loadPackageManagers = initLoader([nullPmModule]);
+            loadPackageManagers = initPMLoader([nullPmModule]);
           });
 
           describe('when provided a version within the accepted range', function () {


### PR DESCRIPTION
BREAKING CHANGE: `midnight-smoker` now runs a small suite of automated checks by default.

BREAKING CHANGE: The `scripts/` dir has been removed from the published package.

BREAKING CHANGE: Events emitted by the `Smoker` class have changed.

The automated checks include:

- a check for banned/sensitive files
- a check for missing CJS entry points
- a check for other missing files (such as a `bin`)
- a check for a valid `exports` field (there are many ways to befoul this)

All of these can be configured via the config file.  To disable checks altogether, use `--no-checks` or `{checks: false}`.  See `schema/midnight-smoker.schema.json` for the config file schema.  More detailed information can be found in `README.md`.