### PR TITLE
chore(ci): do not use npm ci

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,9 +18,9 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - name: Upgrade npm
         run: npm i -g npm@latest
-      - name: Upgrade corepack
-        run: npm i -g corepack@latest
       - name: npm install
         uses: bahmutov/npm-install@5e78a2c1fa3203b777a67764f15380aa7c80d015 # v1.8.34
+        with:
+          install-command: npm install --foreground-scripts
       - name: test
         run: npm run test:ci


### PR DESCRIPTION
`npm ci` rimrafs `node_modules` then installs everything in `package-lock.json`.  However, it is highly likely that the result of running `npm install` in a development environment will result in a very different tree, which updates `package-lock.json`.  If one of the dependencies installed ships a poorly-built shrinkwrap file, the updated `package-lock.json` will contain potentially incompatible software from the shrinkwrap. This will be manifested _upon the next `npm ci`_.

TL;DR: `npm ci` is fast, but using it exclusively in CI can be dangerous.