### PR TITLE
fix(rules): no-missing-exports supports arrays

### DIFF
--- a/test/e2e/rules/fixture/no-missing-exports-array/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-array/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-array/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-array/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-missing-exports-array",
+  "version": "1.0.0",
+  "exports": [
+    "./index.js",
+    "./index-missing.js"
+  ],
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-conditional-array/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional-array/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-conditional-array/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-conditional-array/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "no-missing-exports-conditional-array",
+  "version": "1.0.0",
+  "exports": {
+    "default": [
+      "./index.js",
+      "./index-missing.js"
+    ]
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-array/another-index.cjs
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-array/another-index.cjs
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-array/index.js
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-array/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/e2e/rules/fixture/no-missing-exports-subpath-array/package.json
+++ b/test/e2e/rules/fixture/no-missing-exports-subpath-array/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "no-missing-exports-subpath",
+  "version": "1.0.0",
+  "exports": {
+    ".": [
+      "./index.js",
+      "./another-index.cjs"
+    ]
+  },
+  "type": "module"
+}

--- a/test/e2e/rules/no-missing-exports.spec.ts
+++ b/test/e2e/rules/no-missing-exports.spec.ts
@@ -86,7 +86,7 @@ describe('midnight-smoker', function () {
         });
       });
 
-      describe('when the package contains subpath "exports"', function () {
+      describe('when the package contains subpath "exports" field', function () {
         describe('when a file is missing', function () {
           beforeEach(function () {
             ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-subpath'));
@@ -108,6 +108,32 @@ describe('midnight-smoker', function () {
                 ],
               },
             );
+          });
+
+          describe('when the value is an array', function () {
+            beforeEach(function () {
+              ({ruleConfig, pkg} = setupRuleTest(
+                'no-missing-exports-subpath-array',
+              ));
+            });
+
+            it('should return a RuleFailure', async function () {
+              await expect(
+                applyRules(ruleConfig, pkg, ruleCont),
+                'to be fulfilled with value satisfying',
+                {
+                  passed: expect.it('to be empty'),
+                  failed: [
+                    {
+                      rule: noMissingExports.toJSON(),
+                      message:
+                        'Subpath export "." should be a string instead of an array',
+                      failed: true,
+                    },
+                  ],
+                },
+              );
+            });
           });
         });
 
@@ -195,7 +221,7 @@ describe('midnight-smoker', function () {
         });
       });
 
-      describe('when the package contains conditional "exports"', function () {
+      describe('when the package contains conditional "exports" field', function () {
         describe('when a file is missing', function () {
           beforeEach(function () {
             ({ruleConfig, pkg} = setupRuleTest(
@@ -214,6 +240,32 @@ describe('midnight-smoker', function () {
                     rule: noMissingExports.toJSON(),
                     message:
                       'Export "require" unreadable at path: ./index-missing.js',
+                    failed: true,
+                  },
+                ],
+              },
+            );
+          });
+        });
+
+        describe('when the value is an array', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest(
+              'no-missing-exports-conditional-array',
+            ));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                passed: expect.it('to be empty'),
+                failed: [
+                  {
+                    rule: noMissingExports.toJSON(),
+                    message:
+                      'Export "default" unreadable at path: ./index-missing.js',
                     failed: true,
                   },
                 ],
@@ -360,6 +412,31 @@ describe('midnight-smoker', function () {
                 );
               });
             });
+          });
+        });
+      });
+
+      describe('when the package contains an array "exports" field', function () {
+        describe('when a file is missing', function () {
+          beforeEach(function () {
+            ({ruleConfig, pkg} = setupRuleTest('no-missing-exports-array'));
+          });
+
+          it('should return a RuleFailure', async function () {
+            await expect(
+              applyRules(ruleConfig, pkg, ruleCont),
+              'to be fulfilled with value satisfying',
+              {
+                passed: expect.it('to be empty'),
+                failed: [
+                  {
+                    rule: noMissingExports.toJSON(),
+                    message: 'Export unreadable at path: ./index-missing.js',
+                    failed: true,
+                  },
+                ],
+              },
+            );
           });
         });
       });


### PR DESCRIPTION
It seems like if a subpath export is an array, Node uses only the first item of that array and ignores everything else.  So that's covered.
