### PR TITLE
fix(errors): better error output

### DIFF
--- a/__snapshots__/cli.spec.ts.js
+++ b/__snapshots__/cli.spec.ts.js
@@ -359,3 +359,175 @@ exports['midnight-smoker smoker CLI check when a check fails when the rule sever
 ✔ Successfully ran 3 checks
 ✔ Lovey-dovey! 💖
 `
+
+exports['midnight-smoker smoker CLI when packing fails should provide a reason [snapshot] 1'] = `
+💨 midnight-smoker v<version>
+- Packing current project…
+✖ Failed while packing!
+
+Package manager "npm" failed to pack:
+
+Invalid package, must have name and version
+(use --verbose for more details)
+`
+
+exports['midnight-smoker smoker CLI when packing fails when in verbose mode should provide more detail [snapshot] 1'] = `
+💨 midnight-smoker v<version>
+- Packing current project…
+✖ Failed while packing!
+
+PackError: Package manager "npm" failed to pack:
+
+Invalid package, must have name and version
+    at Npm7.pack (<path/to/file>:<line>:<col>)
+    at processTicksAndRejections (<path/to/file>:<line>:<col>)
+    at Smoker.pack (<path/to/file>:<line>:<col>)
+    at Smoker.smoke (<path/to/file>:<line>:<col>)
+    at Object.handler (<path/to/file>:<line>:<col>) {
+  code: 'ESMOKER_PACK',
+  [cause]: {
+    pm: 'npm',
+    error: Error: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> pack --json --pack-destination=<path/to/dir> --foreground-scripts=false
+    npm ERR! Invalid package, must have name and version
+    
+    npm ERR! A complete log of this run can be found in: <path/to/some>.log
+    {
+      "error": {
+        "code": null,
+        "summary": "Invalid package, must have name and version",
+        "detail": ""
+      }
+    }
+        at makeError (<path/to/file>:<line>:<col>)
+        at handlePromise (<path/to/file>:<line>:<col>)
+        at processTicksAndRejections (<path/to/file>:<line>:<col>)
+        at CorepackExecutor.exec (<path/to/file>:<line>:<col>)
+        at Npm7.pack (<path/to/file>:<line>:<col>)
+        at Smoker.pack (<path/to/file>:<line>:<col>)
+        at Smoker.smoke (<path/to/file>:<line>:<col>)
+        at Object.handler (<path/to/file>:<line>:<col>) {
+      shortMessage: 'Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> pack --json --pack-destination=<path/to/dir> --foreground-scripts=false',
+      command: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> pack --json --pack-destination=<path/to/dir> --foreground-scripts=false',
+      escapedCommand: '"<path/to/>/bin/node" "<path/to/>/.bin/corepack" "npm@<version>" pack --json "--pack-destination=<path/to/dir> "--foreground-scripts=false"',
+      exitCode: 1,
+      signal: undefined,
+      signalDescription: undefined,
+      stdout: '{\\n' +
+        '  "error": {\\n' +
+        '    "code": null,\\n' +
+        '    "summary": "Invalid package, must have name and version",\\n' +
+        '    "detail": ""\\n' +
+        '  }\\n' +
+        '}',
+      stderr: 'npm ERR! Invalid package, must have name and version\\n' +
+        '\\n' +
+        'npm ERR! A complete log of this run can be found in: <path/to/some>.log',
+      failed: true,
+      timedOut: false,
+      isCanceled: false,
+      killed: false
+    },
+    output: 'npm ERR! Invalid package, must have name and version\\n' +
+      '\\n' +
+      'npm ERR! A complete log of this run can be found in: <path/to/some>.log'
+  }
+}
+`
+
+exports['midnight-smoker smoker CLI when installation fails should provide a reason [snapshot] 1'] = `
+💨 midnight-smoker v<version>
+- Packing current project…
+✔ Packed 1 unique package using npm@<version>…
+- Installing 1 unique package from tarball using npm@<version>…
+✖ Failed while installing!
+
+Package manager "npm" failed to install packages
+(use --verbose for more details)
+`
+
+exports['midnight-smoker smoker CLI when installation fails when in verbose mode should provide more detail [snapshot] 1'] = `
+💨 midnight-smoker v<version>
+- Packing current project…
+✔ Packed 1 unique package using npm@<version>…
+- Installing 1 unique package from tarball using npm@<version>…
+✖ Failed while installing!
+
+InstallError: Package manager "npm" failed to install packages
+    at Npm7.install (<path/to/file>:<line>:<col>)
+    at processTicksAndRejections (<path/to/file>:<line>:<col>)
+    at Smoker.install (<path/to/file>:<line>:<col>)
+    at Smoker.smoke (<path/to/file>:<line>:<col>)
+    at Object.handler (<path/to/file>:<line>:<col>) {
+  code: 'ESMOKER_INSTALL',
+  [cause]: {
+    pm: 'npm',
+    error: Error: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> install --no-package-lock --global-style <path/to/some>.tgz
+    npm WARN config global-style This option has been deprecated in favor of \`--install-strategy=shallow\`
+    npm ERR! code ERESOLVE
+    npm ERR! ERESOLVE unable to resolve dependency tree
+    npm ERR! 
+    npm ERR! While resolving: undefined@undefined
+    npm ERR! Found: install-error@1.0.0
+    npm ERR! node_modules/install-error
+    npm ERR!   <path/to/some>.tgz" from the root project
+    npm ERR! 
+    npm ERR! Could not resolve dependency:
+    npm ERR! peer install-error@"2.0.0" from install-error@1.0.0
+    npm ERR! node_modules/install-error
+    npm ERR!   <path/to/some>.tgz" from the root project
+    npm ERR! 
+    npm ERR! Fix the upstream dependency conflict, or retry
+    npm ERR! this command with --force or --legacy-peer-deps
+    npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
+    npm ERR! 
+    npm ERR! 
+    npm ERR! For a full report see:
+    npm ERR! <path/to/some>.txt
+    
+    npm ERR! A complete log of this run can be found in: <path/to/some>.log
+        at makeError (<path/to/file>:<line>:<col>)
+        at handlePromise (<path/to/file>:<line>:<col>)
+        at processTicksAndRejections (<path/to/file>:<line>:<col>)
+        at CorepackExecutor.exec (<path/to/file>:<line>:<col>)
+        at Npm7.install (<path/to/file>:<line>:<col>)
+        at Smoker.install (<path/to/file>:<line>:<col>)
+        at Smoker.smoke (<path/to/file>:<line>:<col>)
+        at Object.handler (<path/to/file>:<line>:<col>) {
+      shortMessage: 'Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> install --no-package-lock --global-style <path/to/some>.tgz',
+      command: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> install --no-package-lock --global-style <path/to/some>.tgz',
+      escapedCommand: '"<path/to/>/bin/node" "<path/to/>/.bin/corepack" "npm@<version>" install --no-package-lock --global-style <path/to/some>.tgz"',
+      exitCode: 1,
+      signal: undefined,
+      signalDescription: undefined,
+      stdout: '',
+      stderr: 'npm WARN config global-style This option has been deprecated in favor of \`--install-strategy=shallow\`\\n' +
+        'npm ERR! code ERESOLVE\\n' +
+        'npm ERR! ERESOLVE unable to resolve dependency tree\\n' +
+        'npm ERR! \\n' +
+        'npm ERR! While resolving: undefined@undefined\\n' +
+        'npm ERR! Found: install-error@1.0.0\\n' +
+        'npm ERR! node_modules/install-error\\n' +
+        'npm ERR!   <path/to/some>.tgz" from the root project\\n' +
+        'npm ERR! \\n' +
+        'npm ERR! Could not resolve dependency:\\n' +
+        'npm ERR! peer install-error@"2.0.0" from install-error@1.0.0\\n' +
+        'npm ERR! node_modules/install-error\\n' +
+        'npm ERR!   <path/to/some>.tgz" from the root project\\n' +
+        'npm ERR! \\n' +
+        'npm ERR! Fix the upstream dependency conflict, or retry\\n' +
+        'npm ERR! this command with --force or --legacy-peer-deps\\n' +
+        'npm ERR! to accept an incorrect (and potentially broken) dependency resolution.\\n' +
+        'npm ERR! \\n' +
+        'npm ERR! \\n' +
+        'npm ERR! For a full report see:\\n' +
+        'npm ERR! <path/to/some>.txt\\n' +
+        '\\n' +
+        'npm ERR! A complete log of this run can be found in: <path/to/some>.log',
+      failed: true,
+      timedOut: false,
+      isCanceled: false,
+      killed: false
+    }
+  }
+}
+`

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "rewiremock": "3.14.5",
         "sinon": "15.2.0",
         "snap-shot-it": "7.9.10",
+        "strip-ansi": "5.2.0",
         "ts-node": "10.9.1",
         "typescript": "5.2.2",
         "unexpected": "13.2.1",
@@ -1884,6 +1885,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2958,6 +2970,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -5238,6 +5262,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/mocha/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5807,6 +5843,17 @@
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -6889,27 +6936,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/snap-shot-compare/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/snap-shot-compare/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/snap-shot-core": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
@@ -7188,6 +7214,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -7276,14 +7313,15 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
     "node_modules/strip-ansi-cjs": {
@@ -7296,6 +7334,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-bom": {
@@ -8000,6 +8047,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -8168,6 +8226,17 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "rewiremock": "3.14.5",
     "sinon": "15.2.0",
     "snap-shot-it": "7.9.10",
+    "strip-ansi": "5.2.0",
     "ts-node": "10.9.1",
     "typescript": "5.2.2",
     "unexpected": "13.2.1",

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,8 +4,8 @@
  */
 
 import {bold} from 'chalk';
-import {SmokeResults} from './types';
 import {StaticCheckContext} from '.';
+import {SmokeResults} from './types';
 
 /**
  * Options for {@link SmokerError} with a generic `Cause` type for `cause` prop.
@@ -56,6 +56,7 @@ export class InvalidArgError extends SmokerError<{arg?: string}> {
 }
 
 export class NotImplementedError extends SmokerError {
+  public readonly name = 'NotImplementedError';
   constructor(message: string) {
     super(message, {code: 'ESMOKER_NOTIMPLEMENTED'});
   }
@@ -64,6 +65,8 @@ export class NotImplementedError extends SmokerError {
 export class DirCreationError extends SmokerError<{
   error: NodeJS.ErrnoException;
 }> {
+  public readonly name = 'DirCreationError';
+
   constructor(message: string, error: NodeJS.ErrnoException) {
     super(message, {code: 'ESMOKER_DIRCREATION', cause: {error}});
   }
@@ -73,6 +76,7 @@ export class DirDeletionError extends SmokerError<{
   dir: string;
   error: NodeJS.ErrnoException;
 }> {
+  public readonly name = 'DirDeletionError';
   constructor(message: string, dir: string, error: NodeJS.ErrnoException) {
     super(message, {code: 'ESMOKER_DIRDELETION', cause: {dir, error}});
   }
@@ -81,6 +85,7 @@ export class DirDeletionError extends SmokerError<{
 export class PackageManagerIdError extends SmokerError<{
   pmId: string;
 }> {
+  public readonly name = 'PackageManagerIdError';
   constructor() {
     super(
       'Could not find package manager ID; please report this bug at https://github.com/boneskull/midnight-smoker/issues/new',
@@ -93,6 +98,7 @@ export class PackageManagerError extends SmokerError<{
   error: Error;
   pmId: string;
 }> {
+  public readonly name = 'PackageManagerError';
   constructor(message: string, pmId: string, error: Error) {
     super(message, {code: 'ESMOKER_PACKAGEMANAGER', cause: {pmId, error}});
   }
@@ -248,12 +254,6 @@ export class UnknownDistTagError extends SmokerError<{
 }> {
   constructor(message: string, pkgName: string, tag: string) {
     super(message, {code: 'ESMOKER_UNKNOWNDISTTAG', cause: {pkgName, tag}});
-  }
-}
-
-export class FatalError extends SmokerError<{error: Error}> {
-  constructor(message: string, error: Error) {
-    super(message, {code: 'ESMOKER_FATAL', cause: {error}});
   }
 }
 

--- a/src/smoker.ts
+++ b/src/smoker.ts
@@ -8,7 +8,6 @@ import StrictEventEmitter from 'strict-event-emitter-types';
 import {
   DirCreationError,
   DirDeletionError,
-  FatalError,
   InvalidArgError,
   PackageManagerError,
   PackageManagerIdError,
@@ -31,10 +30,10 @@ import {
 import {
   CheckContext,
   CheckSeverities,
+  RuleOptions,
   type CheckOptions,
   type RuleCont,
   type StaticCheckContext,
-  RuleOptions,
 } from './rules';
 import {BuiltinRuleConts} from './rules/builtin';
 import {
@@ -670,8 +669,6 @@ export class Smoker extends createStrictEventEmitterClass() {
       }
 
       return smokeResults;
-    } catch (err) {
-      throw new FatalError('midnight-smoker failed unexpectedly', err as Error);
     } finally {
       await this.cleanup();
     }

--- a/test/e2e/cli.spec.ts
+++ b/test/e2e/cli.spec.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import snapshot from 'snap-shot-it';
 import unexpected from 'unexpected';
+import type {RawRunScriptResult} from '../../src/types';
 import {readPackageJson} from '../../src/util';
 import assertions from '../assertions';
 import {execSmoker, fixupOutput} from './helpers';
-import type {RawRunScriptResult} from '../../src/types';
 
 const expect = unexpected.clone().use(assertions);
 
@@ -147,6 +147,79 @@ describe('midnight-smoker', function () {
       });
     });
 
+    describe('when packing fails', function () {
+      const cwd = path.join(__dirname, 'fixture', 'pack-error');
+      let result: RawRunScriptResult;
+
+      before(async function () {
+        try {
+          await execSmoker([], {
+            cwd,
+          });
+          expect.fail('should have failed');
+        } catch (err) {
+          result = err as RawRunScriptResult;
+        }
+      });
+
+      it('should provide a reason [snapshot]', async function () {
+        snapshot(fixupOutput(result.stderr));
+      });
+
+      describe('when in verbose mode', function () {
+        before(async function () {
+          try {
+            await execSmoker(['--verbose'], {
+              cwd,
+            });
+            expect.fail('should have failed');
+          } catch (err) {
+            result = err as RawRunScriptResult;
+          }
+        });
+
+        it('should provide more detail [snapshot]', async function () {
+          snapshot(fixupOutput(result.stderr));
+        });
+      });
+    });
+
+    describe('when installation fails', function () {
+      const cwd = path.join(__dirname, 'fixture', 'install-error');
+      let result: RawRunScriptResult;
+
+      before(async function () {
+        try {
+          result = await execSmoker([], {
+            cwd,
+          });
+        } catch (err) {
+          result = err as RawRunScriptResult;
+        }
+      });
+
+      it('should provide a reason [snapshot]', async function () {
+        snapshot(fixupOutput(result.stderr));
+      });
+
+      describe('when in verbose mode', function () {
+        before(async function () {
+          try {
+            await execSmoker(['--verbose'], {
+              cwd,
+            });
+            expect.fail('should have failed');
+          } catch (err) {
+            result = err as RawRunScriptResult;
+          }
+        });
+
+        it('should provide more detail [snapshot]', async function () {
+          snapshot(fixupOutput(result.stderr));
+        });
+      });
+    });
+
     describe('option', function () {
       describe('--version', function () {
         it('should print version and exit', async function () {
@@ -226,8 +299,8 @@ describe('midnight-smoker', function () {
           before(async function () {
             try {
               await execSmoker(['smoke', '--json', '--no-checks'], {cwd});
-            } catch (e) {
-              result = e as RawRunScriptResult;
+            } catch (err) {
+              result = err as RawRunScriptResult;
             }
           });
 

--- a/test/e2e/fixture/install-error/package.json
+++ b/test/e2e/fixture/install-error/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "install-error",
+  "version": "1.0.0",
+  "description": "this should be hard to install",
+  "peerDependencies": {
+    "install-error": "2.0.0"
+  }
+}

--- a/test/e2e/fixture/pack-error/package.json
+++ b/test/e2e/fixture/pack-error/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pack-error",
+  "description": "npm wants a version field or else"
+}


### PR DESCRIPTION
- Remove `FatalError` since it was not really helping
- Upon pack or install error, verbose mode will dump the entire nested error structure
- Use canned error msgs for the two event listeners, since the real ones get thrown immediately after the `emit()`, then we catch them in the command handler
- Retrieves error summaries from npm output, if available (is there a yarn analogue?)
- Closes #338 
