### PR TITLE
chore!: drop node.js v16 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [16, 18, 20]
+        node_version: [18, 20]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@commitlint/cli": "17.8.1",
         "@commitlint/config-conventional": "17.8.1",
-        "@tsconfig/node16": "16.1.1",
+        "@tsconfig/node18": "18.2.2",
         "@types/mocha": "10.0.3",
         "@types/node": "18.18.6",
         "@types/sinon": "10.0.20",
@@ -47,7 +47,7 @@
         "unexpected-sinon": "11.1.0"
       },
       "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+        "node": "^18.12.0 || ^20.0.0",
         "npm": ">=7"
       }
     },
@@ -781,10 +781,10 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
       "dev": true
     },
     "node_modules/@types/debug": {
@@ -8376,7 +8376,7 @@
         "zod-to-json-schema": "3.21.4"
       },
       "engines": {
-        "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+        "node": "^18.12.0 || ^20.0.0",
         "npm": ">=7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+    "node": "^18.12.0 || ^20.0.0",
     "npm": ">=7"
   },
   "scripts": {
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@commitlint/cli": "17.8.1",
     "@commitlint/config-conventional": "17.8.1",
-    "@tsconfig/node16": "16.1.1",
+    "@tsconfig/node18": "18.2.2",
     "@types/mocha": "10.0.3",
     "@types/node": "18.18.6",
     "@types/sinon": "10.0.20",

--- a/packages/midnight-smoker/__snapshots__/cli.spec.ts.js
+++ b/packages/midnight-smoker/__snapshots__/cli.spec.ts.js
@@ -384,6 +384,7 @@ Invalid package, must have name and version
     at Smoker.pack (<path/to/file>:<line>:<col>)
     at Smoker.smoke (<path/to/file>:<line>:<col>)
     at Object.handler (<path/to/file>:<line>:<col>) {
+  code: 'ESMOKER_PACK',
   cause: {
     pm: 'npm',
     error: Error: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> pack --json --pack-destination=<path/to/dir> --foreground-scripts=false
@@ -429,8 +430,7 @@ Invalid package, must have name and version
     output: 'npm ERR! Invalid package, must have name and version\\n' +
       '\\n' +
       'npm ERR! A complete log of this run can be found in: <path/to/some>.log'
-  },
-  code: 'ESMOKER_PACK'
+  }
 }
 `
 
@@ -458,6 +458,7 @@ InstallError: Package manager "npm" failed to install packages
     at Smoker.install (<path/to/file>:<line>:<col>)
     at Smoker.smoke (<path/to/file>:<line>:<col>)
     at Object.handler (<path/to/file>:<line>:<col>) {
+  code: 'ESMOKER_INSTALL',
   cause: {
     pm: 'npm',
     error: Error: Command failed with exit code 1: <path/to/>/bin/node <path/to/>/.bin/corepack npm@<version> install --no-audit --no-package-lock --install-strategy=shallow <path/to/some>.tgz
@@ -525,7 +526,6 @@ InstallError: Package manager "npm" failed to install packages
       isCanceled: false,
       killed: false
     }
-  },
-  code: 'ESMOKER_INSTALL'
+  }
 }
 `

--- a/packages/midnight-smoker/package.json
+++ b/packages/midnight-smoker/package.json
@@ -14,7 +14,7 @@
   "author": "Christopher Hiller <boneskull@boneskull.com> (https://boneskull.com/)",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16.20.0 || ^18.0.0 || ^20.0.0",
+    "node": "^18.12.0 || ^20.0.0",
     "npm": ">=7"
   },
   "bin": {

--- a/packages/midnight-smoker/src/error.ts
+++ b/packages/midnight-smoker/src/error.ts
@@ -10,7 +10,8 @@ import {SmokeResults} from './types';
 /**
  * Options for {@link SmokerError} with a generic `Cause` type for `cause` prop.
  */
-export interface SmokerErrorOpts<Cause extends object | void = void> {
+export interface SmokerErrorOpts<Cause extends object | void = void>
+  extends ErrorOptions {
   code?: string;
   cause?: Cause;
 }

--- a/packages/midnight-smoker/src/tsconfig.json
+++ b/packages/midnight-smoker/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
     "declaration": true,

--- a/packages/midnight-smoker/test/tsconfig.json
+++ b/packages/midnight-smoker/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "types": ["node", "mocha"],
     "noEmit": true,

--- a/packages/midnight-smoker/tsconfig.json
+++ b/packages/midnight-smoker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "files": [],
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
BREAKING CHANGE: This drops support for Node.js v16, which is now EOL.

Many dependencies seem to be dropping it rather quickly, so this package will follow suit.